### PR TITLE
Attempt to optimize tokenizer

### DIFF
--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -3,8 +3,8 @@ import { equalizeWhitespace, escapeRegExp, id } from 'src/utils';
 import * as regexFactory from './regexFactory';
 import { type Token, TokenType } from './token';
 
-export const WHITESPACE_REGEX = /^(\s+)/u;
-const NULL_REGEX = /(?!)/; // zero-width negative lookahead, matches nothing
+const WHITESPACE_REGEX = /(\s+)/uy;
+const NULL_REGEX = /(?!)/uy; // zero-width negative lookahead, matches nothing
 
 const toCanonicalKeyword = (text: string) => equalizeWhitespace(text.toUpperCase());
 
@@ -117,12 +117,12 @@ export default class Tokenizer {
       ]),
       [TokenType.BLOCK_START]: regexFactory.createParenRegex(cfg.blockStart ?? ['(']),
       [TokenType.BLOCK_END]: regexFactory.createParenRegex(cfg.blockEnd ?? [')']),
-      [TokenType.RESERVED_CASE_START]: /^(CASE)\b/iu,
-      [TokenType.RESERVED_CASE_END]: /^(END)\b/iu,
+      [TokenType.RESERVED_CASE_START]: /(CASE)\b/iuy,
+      [TokenType.RESERVED_CASE_END]: /(END)\b/iuy,
       [TokenType.LINE_COMMENT]: regexFactory.createLineCommentRegex(cfg.lineCommentTypes ?? ['--']),
-      [TokenType.BLOCK_COMMENT]: /^(\/\*[^]*?(?:\*\/|$))/u,
+      [TokenType.BLOCK_COMMENT]: /(\/\*[^]*?(?:\*\/|$))/uy,
       [TokenType.NUMBER]:
-        /^(0x[0-9a-fA-F]+|0b[01]+|(-\s*)?[0-9]+(\.[0-9]*)?([eE][-+]?[0-9]+(\.[0-9]+)?)?)/u,
+        /(0x[0-9a-fA-F]+|0b[01]+|(-\s*)?[0-9]+(\.[0-9]*)?([eE][-+]?[0-9]+(\.[0-9]+)?)?)/uy,
       [TokenType.PARAMETER]: NULL_REGEX, // matches nothing
       [TokenType.EOF]: NULL_REGEX, // matches nothing
     };
@@ -152,7 +152,7 @@ export default class Tokenizer {
       },
       {
         // ? placeholders
-        regex: cfg.positionalParams ? /^(\?)/ : undefined,
+        regex: cfg.positionalParams ? /(\?)/uy : undefined,
         parseKey: v => v.slice(1),
       },
     ]);
@@ -198,6 +198,7 @@ export default class Tokenizer {
 
   /** Matches preceding whitespace if present */
   private getWhitespace(input: string): string {
+    WHITESPACE_REGEX.lastIndex = 0;
     const matches = input.match(WHITESPACE_REGEX);
     return matches ? matches[1] : '';
   }
@@ -314,6 +315,7 @@ export default class Tokenizer {
     regex: RegExp;
     transform: (s: string) => string;
   }): Token | undefined {
+    regex.lastIndex = 0;
     const matches = input.match(regex);
     if (matches) {
       return {

--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -199,7 +199,6 @@ export default class Tokenizer {
     return this.preprocess(tokens);
   }
 
-  /** Matches preceding whitespace if present */
   private getWhitespace(): string {
     WHITESPACE_REGEX.lastIndex = this.index;
     const matches = this.input.match(WHITESPACE_REGEX);
@@ -212,7 +211,6 @@ export default class Tokenizer {
     }
   }
 
-  /** Attempts to match next token from input string, tests RegExp patterns in decreasing priority */
   private getNextToken(previousToken?: Token): Token | undefined {
     return (
       this.matchToken(TokenType.LINE_COMMENT) ||
@@ -230,10 +228,6 @@ export default class Tokenizer {
     );
   }
 
-  /**
-   * Attempts to match a placeholder token pattern
-   * @return {Token | undefined} - The placeholder token if found, otherwise undefined
-   */
   private matchPlaceholderToken(): Token | undefined {
     for (const { regex, parseKey } of this.paramPatterns) {
       const token = this.match({
@@ -260,10 +254,6 @@ export default class Tokenizer {
     });
   }
 
-  /**
-   * Attempts to match a Reserved word token pattern, avoiding edge cases of Reserved words within string tokens
-   * @return {Token | undefined} - The Reserved word token if found, otherwise undefined
-   */
   private matchReservedWordToken(previousToken?: Token): Token | undefined {
     // A reserved word cannot be preceded by a '.'
     // this makes it so in "mytable.from", "from" is not considered a reserved word

--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -3,6 +3,18 @@ import { equalizeWhitespace, escapeRegExp, id } from 'src/utils';
 import * as regexFactory from './regexFactory';
 import { type Token, TokenType } from './token';
 
+// A note about regular expressions
+//
+// We're using a sticky flag "y" in all tokenizing regexes.
+// This works a bit like ^, anchoring the regex to the start,
+// but when ^ anchores the regex to the start of string (or line),
+// the sticky flag anchors it to search start position, which we
+// can change by setting RegExp.lastIndex.
+//
+// This allows us to avoid slicing off tokens from the start of input string
+// (which we used in the past) and just move the match start position forward,
+// which is much more performant on long strings.
+
 const WHITESPACE_REGEX = /(\s+)/uy;
 const NULL_REGEX = /(?!)/uy; // zero-width negative lookahead, matches nothing
 

--- a/src/core/formatCommaPositions.ts
+++ b/src/core/formatCommaPositions.ts
@@ -1,7 +1,7 @@
 import type { CommaPosition } from 'src/types';
 import { maxLength } from 'src/utils';
 
-import { WHITESPACE_REGEX } from './Tokenizer';
+const WHITESPACE_REGEX = /^(\s+)/u;
 
 /**
  * Handles comma placement - either before, after or tabulated

--- a/src/core/regexFactory.ts
+++ b/src/core/regexFactory.ts
@@ -63,8 +63,8 @@ export const createOperatorRegex = (monadOperators: string, polyadOperators: str
  */
 export const createLineCommentRegex = (lineCommentTypes: string[]): RegExp =>
   new RegExp(
-    `^((?:${lineCommentTypes.map(c => escapeRegExp(c)).join('|')}).*?)(?:\r\n|\r|\n|$)`,
-    'u'
+    `((?:${lineCommentTypes.map(c => escapeRegExp(c)).join('|')}).*?)(?:\r\n|\r|\n|$)`,
+    'uy'
   );
 
 /**
@@ -75,7 +75,7 @@ export const createReservedWordRegex = (
   identChars: IdentChars = {}
 ): RegExp => {
   if (reservedKeywords.length === 0) {
-    return /^\b$/u;
+    return /\b$/uy;
   }
 
   const avoidIdentChars = rejectIdentCharsPattern(identChars);
@@ -84,7 +84,7 @@ export const createReservedWordRegex = (
     .join('|')
     .replace(/ /gu, '\\s+');
 
-  return new RegExp(`^(${reservedKeywordsPattern})${avoidIdentChars}\\b`, 'iu');
+  return new RegExp(`(${reservedKeywordsPattern})${avoidIdentChars}\\b`, 'iuy');
 };
 
 // Negative lookahead to avoid matching a keyword that's actually part of identifier,
@@ -192,4 +192,4 @@ export const createParameterRegex = (types: string[], pattern: string): RegExp |
   return patternToRegex(`(?:${typesRegex})(?:${pattern})`);
 };
 
-const patternToRegex = (pattern: string): RegExp => new RegExp('^(' + pattern + ')', 'u');
+const patternToRegex = (pattern: string): RegExp => new RegExp('(' + pattern + ')', 'uy');


### PR DESCRIPTION
Instead of chewing off bits from the input string, move the regex matching start position forward.

Measured the performance from command line and in browsers using https://jsben.ch site using the following code:

```js
sqlFormatter.format("select supplier_name,city from (select * from suppliers join addresses on suppliers.address_id=addresses.id) as suppliers where supplier_id>500 order by supplier_name asc,city desc; ALTER TABLE `Album` ADD CONSTRAINT `FK_AlbumArtistId` FOREIGN KEY (`ArtistId`) REFERENCES `Artist` (`ArtistId`) ON DELETE NO ACTION ON UPDATE NO ACTION; CREATE TABLE `Customer` ( `CustomerId` INT NOT NULL AUTO_INCREMENT, `FirstName` NVARCHAR(40) NOT NULL, `LastName` NVARCHAR(20) NOT NULL, `Company` NVARCHAR(80), `Address` NVARCHAR(70), `City` NVARCHAR(40), `State` NVARCHAR(40), `Country` NVARCHAR(40), `PostalCode` NVARCHAR(10), `Phone` NVARCHAR(24), `Fax` NVARCHAR(24), `Email` NVARCHAR(60) NOT NULL, `SupportRepId` INT, CONSTRAINT `PK_Customer` PRIMARY KEY  (`CustomerId`)); INSERT INTO `Track` (`Name`, `AlbumId`, `MediaTypeId`, `GenreId`, `Composer`, `Milliseconds`, `Bytes`, `UnitPrice`) VALUES (N'Jump Around', 258, 1, 17, N'E. Schrody/L. Muggerud', 217835, 8715653, 0.99); INSERT INTO `Track` (`Name`, `AlbumId`, `MediaTypeId`, `GenreId`, `Composer`, `Milliseconds`, `Bytes`, `UnitPrice`) VALUES (N'Salutations', 258, 1, 17, N'E. Schrody/L. Dimant', 69120, 2767047, 0.99); INSERT INTO `Track` (`Name`, `AlbumId`, `MediaTypeId`, `GenreId`, `Composer`, `Milliseconds`, `Bytes`, `UnitPrice`) VALUES (N'Put Your Head Out', 258, 1, 17, N'E. Schrody/L. Freese/L. Muggerud', 182230, 7291473, 0.99); INSERT INTO `Track` (`Name`, `AlbumId`, `MediaTypeId`, `GenreId`, `Composer`, `Milliseconds`, `Bytes`, `UnitPrice`) VALUES (N'Top O'' The Morning To Ya', 258, 1, 17, N'E. Schrody/L. Dimant', 216633, 8667599, 0.99); INSERT INTO `Invoice` (`CustomerId`, `InvoiceDate`, `BillingAddress`, `BillingCity`, `BillingState`, `BillingCountry`, `BillingPostalCode`, `Total`) VALUES (48, '2013/8/2', N'Lijnbaansgracht 120bg', N'Amsterdam', N'VV', N'Netherlands', N'1016', 1.98);", {
  language: "sql",
});
```

Also did another measurement with 10x longer input string. 

- NodeJS: no difference (7 x faster with longer string)
- Chrome: 3 x faster (15 x faster with longer string)
- Firefox: 2 x faster (10 x faster with longer string)
- Safari: 3 x faster (25 x faster with longer string)

For some reason though I'm failing to see any performance difference when using sql-formatter program from command line with a large input file. However when using it as a library I do see a difference in NodeJS.