### PR TITLE
Move Alias AS processing out of formatting phase

### DIFF
--- a/src/core/StatementFormatter.ts
+++ b/src/core/StatementFormatter.ts
@@ -421,22 +421,22 @@ export default class StatementFormatter {
   }
 
   /** Returns the latest encountered reserved keyword token */
-  public getPreviousReservedToken(): Token {
+  private getPreviousReservedToken(): Token {
     return this.previousReservedToken;
   }
 
   /** True when currently within SELECT command */
-  public isWithinSelect(): boolean {
+  private isWithinSelect(): boolean {
     return isToken.SELECT(this.previousCommandToken);
   }
 
   /** Fetches nth previous token from the token stream */
-  public tokenLookBehind(n = 1): Token {
+  private tokenLookBehind(n = 1): Token {
     return this.tokens[this.index - n] || EOF_TOKEN;
   }
 
   /** Fetches nth next token from the token stream */
-  public tokenLookAhead(n = 1): Token {
+  private tokenLookAhead(n = 1): Token {
     return this.tokens[this.index + n] || EOF_TOKEN;
   }
 }


### PR DESCRIPTION
It's confusing to have the addition and removal of tokens happening in the middle of formatting. Better to do this in a separate phase altogether.