### PR TITLE
8.0: Disable features

### DIFF
--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -330,8 +330,6 @@ export default class ExpressionFormatter {
         !preserveWhitespaceFor.includes(this.tokenLookBehind().type)
       ) {
         this.query.add(WS.NO_SPACE, node.openParen);
-      } else if (!this.cfg.newlineBeforeOpenParen) {
-        this.query.add(WS.NO_NEWLINE, WS.SPACE, node.openParen);
       } else {
         this.query.add(node.openParen);
       }
@@ -344,11 +342,7 @@ export default class ExpressionFormatter {
         }
       });
 
-      if (this.cfg.newlineBeforeCloseParen) {
-        this.query.add(WS.NEWLINE, WS.INDENT, node.closeParen, WS.SPACE);
-      } else {
-        this.query.add(WS.NO_NEWLINE, WS.SPACE, node.closeParen, WS.SPACE);
-      }
+      this.query.add(WS.NEWLINE, WS.INDENT, node.closeParen, WS.SPACE);
     }
   }
 
@@ -371,10 +365,8 @@ export default class ExpressionFormatter {
     if (isTabularStyle(this.cfg)) {
       // +1 extra indentation step for the closing paren
       this.query.add(WS.NEWLINE, WS.INDENT, WS.SINGLE_INDENT, this.show(token), WS.SPACE);
-    } else if (this.cfg.newlineBeforeCloseParen) {
-      this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
     } else {
-      this.query.add(WS.NO_NEWLINE, WS.SPACE, this.show(token), WS.SPACE);
+      this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
     }
   }
 

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -7,7 +7,6 @@ import supportsNumbers from './features/numbers';
 import supportsTabWidth from './options/tabWidth';
 import supportsUseTabs from './options/useTabs';
 import supportsAliasAs from './options/aliasAs';
-import supportsMultilineLists from './options/multilineLists';
 import supportsExpressionWidth from './options/expressionWidth';
 import supportsKeywordCase from './options/keywordCase';
 import supportsCommaPosition from './options/commaPosition';
@@ -30,7 +29,7 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
   supportsKeywordCase(format);
   // supportsIndentStyle(format); // XXX: Feature is disabled for now
   supportsLinesBetweenQueries(format);
-  supportsMultilineLists(format);
+  // supportsMultilineLists(format); // XXX: Feature is disabled for now
   supportsExpressionWidth(format);
   // supportsNewlineBeforeParen(format); // XXX: Feature is disabled for now
   supportsNewlineBeforeSemicolon(format);

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -11,7 +11,6 @@ import supportsMultilineLists from './options/multilineLists';
 import supportsExpressionWidth from './options/expressionWidth';
 import supportsKeywordCase from './options/keywordCase';
 import supportsIndentStyle from './options/indentStyle';
-import supportsNewlineBeforeParen from './options/newlineBeforeParen';
 import supportsCommaPosition from './options/commaPosition';
 import supportsLinesBetweenQueries from './options/linesBetweenQueries';
 import supportsNewlineBeforeSemicolon from './options/newlineBeforeSemicolon';
@@ -34,7 +33,7 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
   supportsLinesBetweenQueries(format);
   supportsMultilineLists(format);
   supportsExpressionWidth(format);
-  supportsNewlineBeforeParen(format);
+  // supportsNewlineBeforeParen(format); // XXX: Feature is disabled for now
   supportsNewlineBeforeSemicolon(format);
   supportsCommaPosition(format);
   supportsLogicalOperatorNewline(format);

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -10,7 +10,6 @@ import supportsAliasAs from './options/aliasAs';
 import supportsMultilineLists from './options/multilineLists';
 import supportsExpressionWidth from './options/expressionWidth';
 import supportsKeywordCase from './options/keywordCase';
-import supportsIndentStyle from './options/indentStyle';
 import supportsCommaPosition from './options/commaPosition';
 import supportsLinesBetweenQueries from './options/linesBetweenQueries';
 import supportsNewlineBeforeSemicolon from './options/newlineBeforeSemicolon';
@@ -29,7 +28,7 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
   supportsTabWidth(format);
   supportsUseTabs(format);
   supportsKeywordCase(format);
-  supportsIndentStyle(format);
+  // supportsIndentStyle(format); // XXX: Feature is disabled for now
   supportsLinesBetweenQueries(format);
   supportsMultilineLists(format);
   supportsExpressionWidth(format);

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -110,7 +110,7 @@ export default function supportsCase(format: FormatFn) {
     `);
   });
 
-  it('breaks SELECT with CASE to multiple lines even when multilineLists:avoid is used', () => {
+  it.skip('breaks SELECT with CASE to multiple lines even when multilineLists:avoid is used', () => {
     const result = format("SELECT foo, bar, CASE baz WHEN 'one' THEN 1 ELSE 2 END FROM tbl;", {
       multilineLists: 'avoid',
     });

--- a/test/options/tabulateAlias.ts
+++ b/test/options/tabulateAlias.ts
@@ -95,7 +95,7 @@ export default function supportsTabulateAlias(format: FormatFn) {
     `);
   });
 
-  it('does not tabulate aliases when multilineLists:avoid used', () => {
+  it.skip('does not tabulate aliases when multilineLists:avoid used', () => {
     const result = format(
       'SELECT alpha AS alp, MAX(beta), epsilon AS E FROM ( SELECT mu AS m, iota AS io FROM gamma );',
       { multilineLists: 'avoid', tabulateAlias: true }

--- a/test/options/tabulateAlias.ts
+++ b/test/options/tabulateAlias.ts
@@ -110,7 +110,7 @@ export default function supportsTabulateAlias(format: FormatFn) {
     `);
   });
 
-  it('works together with indentStyle:tabularLeft', () => {
+  it.skip('works together with indentStyle:tabularLeft', () => {
     const result = format(
       dedent`SELECT alpha AS alp, MAX(beta), epsilon AS E FROM ( SELECT mu AS m, iota AS io FROM gamma );`,
       { indentStyle: 'tabularLeft', tabulateAlias: true }
@@ -128,7 +128,7 @@ export default function supportsTabulateAlias(format: FormatFn) {
     `);
   });
 
-  it('works together with indentStyle:tabularRight', () => {
+  it.skip('works together with indentStyle:tabularRight', () => {
     const result = format(
       dedent`SELECT alpha AS alp, MAX(beta), epsilon AS E FROM ( SELECT mu AS m, iota AS io FROM gamma );`,
       { indentStyle: 'tabularRight', tabulateAlias: true }


### PR DESCRIPTION
To make it easier to work on the new parser I dropped some features (at least for now):

- newlineBeforeOpenParen / newlineBeforeCloseParen
- multilineLists
- indentStyle