### PR TITLE
8.0: Detect SELECT * in Parser

### DIFF
--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -5,7 +5,14 @@ import Indentation from './Indentation';
 import InlineBlock from './InlineBlock';
 import Params from './Params';
 import { isReserved, type Token, TokenType, EOF_TOKEN } from './token';
-import { AstNode, BetweenPredicate, isTokenNode, LimitClause, Parenthesis } from './ast';
+import {
+  AllColumnsAsterisk,
+  AstNode,
+  BetweenPredicate,
+  isTokenNode,
+  LimitClause,
+  Parenthesis,
+} from './ast';
 import { indentString } from './config';
 import WhitespaceBuilder, { WS } from './WhitespaceBuilder';
 
@@ -44,6 +51,9 @@ export default class ExpressionFormatter {
           break;
         case 'limit_clause':
           this.formatLimitClause(node);
+          break;
+        case 'all_columns_asterisk':
+          this.formatAllColumnsAsterisk(node);
           break;
         case 'token':
           this.formatToken(node.token);
@@ -117,6 +127,11 @@ export default class ExpressionFormatter {
     } else {
       this.query.add(this.show(node.countToken), WS.SPACE);
     }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private formatAllColumnsAsterisk(node: AllColumnsAsterisk) {
+    this.query.add('*', WS.SPACE);
   }
 
   private formatToken(token: Token): void {
@@ -248,8 +263,7 @@ export default class ExpressionFormatter {
     }
 
     // other operators
-    // in dense operators mode do not trim whitespace if SELECT *
-    if (this.cfg.denseOperators && this.tokenLookBehind().type !== TokenType.RESERVED_COMMAND) {
+    if (this.cfg.denseOperators) {
       this.query.add(WS.NO_SPACE, this.show(token));
     } else {
       this.query.add(this.show(token), WS.SPACE);

--- a/src/core/Parser.ts
+++ b/src/core/Parser.ts
@@ -1,5 +1,13 @@
 /* eslint-disable no-cond-assign */
-import { AstNode, BetweenPredicate, LimitClause, Parenthesis, Statement, TokenNode } from './ast';
+import {
+  AllColumnsAsterisk,
+  AstNode,
+  BetweenPredicate,
+  LimitClause,
+  Parenthesis,
+  Statement,
+  TokenNode,
+} from './ast';
 import { EOF_TOKEN, type Token, TokenType, isToken } from './token';
 
 /**
@@ -40,7 +48,11 @@ export default class Parser {
 
   private expression(): AstNode {
     return (
-      this.parenthesis() || this.betweenPredicate() || this.limitClause() || this.nextTokenNode()
+      this.parenthesis() ||
+      this.betweenPredicate() ||
+      this.limitClause() ||
+      this.allColumnsAsterisk() ||
+      this.nextTokenNode()
     );
   }
 
@@ -90,6 +102,14 @@ export default class Parser {
         limitToken: this.next(),
         countToken: this.next(),
       };
+    }
+    return undefined;
+  }
+
+  private allColumnsAsterisk(): AllColumnsAsterisk | undefined {
+    if (this.look().value === '*' && isToken.SELECT(this.look(-1))) {
+      this.next();
+      return { type: 'all_columns_asterisk' };
     }
     return undefined;
   }

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -37,6 +37,11 @@ export type LimitClause = {
   offsetToken?: Token;
 };
 
-export type AstNode = Parenthesis | BetweenPredicate | LimitClause | TokenNode;
+// The "*" operator used in SELECT *
+export type AllColumnsAsterisk = {
+  type: 'all_columns_asterisk';
+};
+
+export type AstNode = Parenthesis | BetweenPredicate | LimitClause | AllColumnsAsterisk | TokenNode;
 
 export const isTokenNode = (node: AstNode): node is TokenNode => node.type === 'token';

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -270,4 +270,28 @@ describe('Parser', () => {
       ]
     `);
   });
+
+  it('parses SELECT *', () => {
+    expect(parse('SELECT *')).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "children": Array [
+            Object {
+              "token": Object {
+                "text": "SELECT",
+                "type": "RESERVED_COMMAND",
+                "value": "SELECT",
+                "whitespaceBefore": "",
+              },
+              "type": "token",
+            },
+            Object {
+              "type": "all_columns_asterisk",
+            },
+          ],
+          "type": "statement",
+        },
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
Detection of the `*` operator when used in `SELECT *`. Now detected inside Parser instead having to do a lookbehind while formatting.