### PR TITLE
8.0: Detect function calls inside Parser

### DIFF
--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -251,10 +251,10 @@ export default class ExpressionFormatter {
     } else if (token.value === ';') {
       this.formatQuerySeparator(token);
       return;
-    } else if (['$', '['].includes(token.value)) {
+    } else if (['$'].includes(token.value)) {
       this.query.add(this.show(token));
       return;
-    } else if ([':', ']'].includes(token.value)) {
+    } else if ([':'].includes(token.value)) {
       this.query.add(WS.NO_SPACE, this.show(token), WS.SPACE);
       return;
     } else if (['.', '{', '}', '`'].includes(token.value)) {

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -251,9 +251,6 @@ export default class ExpressionFormatter {
     } else if (token.value === ';') {
       this.formatQuerySeparator(token);
       return;
-    } else if (['$'].includes(token.value)) {
-      this.query.add(this.show(token));
-      return;
     } else if ([':'].includes(token.value)) {
       this.query.add(WS.NO_SPACE, this.show(token), WS.SPACE);
       return;

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -257,7 +257,7 @@ export default class ExpressionFormatter {
     } else if ([':'].includes(token.value)) {
       this.query.add(WS.NO_SPACE, this.show(token), WS.SPACE);
       return;
-    } else if (['.', '{', '}', '`'].includes(token.value)) {
+    } else if (['.', '`'].includes(token.value)) {
       this.query.add(WS.NO_SPACE, this.show(token));
       return;
     }

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -251,10 +251,10 @@ export default class ExpressionFormatter {
     } else if (token.value === ';') {
       this.formatQuerySeparator(token);
       return;
-    } else if ([':'].includes(token.value)) {
+    } else if (token.value === ':') {
       this.query.add(WS.NO_SPACE, this.show(token), WS.SPACE);
       return;
-    } else if (['.'].includes(token.value)) {
+    } else if (token.value === '.') {
       this.query.add(WS.NO_SPACE, this.show(token));
       return;
     }

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -254,7 +254,7 @@ export default class ExpressionFormatter {
     } else if ([':'].includes(token.value)) {
       this.query.add(WS.NO_SPACE, this.show(token), WS.SPACE);
       return;
-    } else if (['.', '`'].includes(token.value)) {
+    } else if (['.'].includes(token.value)) {
       this.query.add(WS.NO_SPACE, this.show(token));
       return;
     }

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -11,12 +11,17 @@ export type TokenNode = {
   token: Token;
 };
 
+export type FunctionCall = {
+  type: 'function_call';
+  nameToken: Token;
+  parenthesis: Parenthesis;
+};
+
 export type Parenthesis = {
   type: 'parenthesis';
   children: AstNode[];
   openParen: string;
   closeParen: string;
-  hasWhitespaceBefore: boolean;
 };
 
 // BETWEEN <expr1> AND <expr2>
@@ -42,6 +47,12 @@ export type AllColumnsAsterisk = {
   type: 'all_columns_asterisk';
 };
 
-export type AstNode = Parenthesis | BetweenPredicate | LimitClause | AllColumnsAsterisk | TokenNode;
+export type AstNode =
+  | FunctionCall
+  | Parenthesis
+  | BetweenPredicate
+  | LimitClause
+  | AllColumnsAsterisk
+  | TokenNode;
 
 export const isTokenNode = (node: AstNode): node is TokenNode => node.type === 'token';

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -49,11 +49,11 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
 
   it('formats complex SELECT', () => {
     const result = format(
-      "SELECT DISTINCT [name], ROUND(age/7) field1, 18 + 20 AS field2, 'some string' FROM foo;"
+      "SELECT DISTINCT name, ROUND(age/7) field1, 18 + 20 AS field2, 'some string' FROM foo;"
     );
     expect(result).toBe(dedent`
       SELECT
-        DISTINCT [name],
+        DISTINCT name,
         ROUND(age / 7) field1,
         18 + 20 AS field2,
         'some string'

--- a/test/features/operators.ts
+++ b/test/features/operators.ts
@@ -30,16 +30,6 @@ export default function supportsOperators(
     });
   });
 
-  it('supports braces', () => {
-    const result = format(`SELECT $\{a} FROM $\{b};`);
-    expect(result).toBe(dedent`
-      SELECT
-        $\{a}
-      FROM
-        $\{b};
-    `);
-  });
-
   it('supports set operators', () => {
     expect(format('foo ALL bar')).toBe('foo ALL bar');
     expect(format('foo = ANY (1, 2, 3)')).toBe('foo = ANY (1, 2, 3)');

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -70,7 +70,7 @@ describe('PlSqlFormatter', () => {
   it('does not support #, $ in named parameters', () => {
     expect(format('SELECT :col$foo')).toBe(dedent`
       SELECT
-        :col $foo
+        :col $ foo
     `);
 
     expect(() => format('SELECT :col#foo')).toThrowError('Parse error: Unexpected "#foo"');

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -56,7 +56,7 @@ describe('SqlFormatter', () => {
         @ name,
       : bar
       FROM
-      {foo};
+        { foo };
     `);
   });
 });

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -8,7 +8,7 @@ describe('Parser', () => {
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedBinaryCommands: ['UNION', 'JOIN'],
       reservedJoinConditions: ['ON', 'USING'],
-      reservedKeywords: ['BETWEEN', 'LIKE'],
+      reservedKeywords: ['BETWEEN', 'LIKE', 'SQRT'],
       stringTypes: ["''"],
       identTypes: ['""'],
     }).tokenize(sql);
@@ -63,8 +63,8 @@ describe('Parser', () => {
     `);
   });
 
-  it('parses parenthesized expressions', () => {
-    expect(parse('SELECT abs(birth_year - year(CURRENT_DATE))')).toMatchInlineSnapshot(`
+  it('parses function call', () => {
+    expect(parse('SELECT SQRT(2)')).toMatchInlineSnapshot(`
       Array [
         Object {
           "children": Array [
@@ -78,11 +78,48 @@ describe('Parser', () => {
               "type": "token",
             },
             Object {
-              "token": Object {
-                "text": "abs",
-                "type": "IDENT",
-                "value": "abs",
+              "nameToken": Object {
+                "text": "SQRT",
+                "type": "RESERVED_KEYWORD",
+                "value": "SQRT",
                 "whitespaceBefore": " ",
+              },
+              "parenthesis": Object {
+                "children": Array [
+                  Object {
+                    "token": Object {
+                      "text": "2",
+                      "type": "NUMBER",
+                      "value": "2",
+                      "whitespaceBefore": "",
+                    },
+                    "type": "token",
+                  },
+                ],
+                "closeParen": ")",
+                "openParen": "(",
+                "type": "parenthesis",
+              },
+              "type": "function_call",
+            },
+          ],
+          "type": "statement",
+        },
+      ]
+    `);
+  });
+
+  it('parses parenthesized expressions', () => {
+    expect(parse('SELECT (birth_year - (CURRENT_DATE + 1))')).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "children": Array [
+            Object {
+              "token": Object {
+                "text": "SELECT",
+                "type": "RESERVED_COMMAND",
+                "value": "SELECT",
+                "whitespaceBefore": "",
               },
               "type": "token",
             },
@@ -107,15 +144,6 @@ describe('Parser', () => {
                   "type": "token",
                 },
                 Object {
-                  "token": Object {
-                    "text": "year",
-                    "type": "IDENT",
-                    "value": "year",
-                    "whitespaceBefore": " ",
-                  },
-                  "type": "token",
-                },
-                Object {
                   "children": Array [
                     Object {
                       "token": Object {
@@ -126,15 +154,31 @@ describe('Parser', () => {
                       },
                       "type": "token",
                     },
+                    Object {
+                      "token": Object {
+                        "text": "+",
+                        "type": "OPERATOR",
+                        "value": "+",
+                        "whitespaceBefore": " ",
+                      },
+                      "type": "token",
+                    },
+                    Object {
+                      "token": Object {
+                        "text": "1",
+                        "type": "NUMBER",
+                        "value": "1",
+                        "whitespaceBefore": " ",
+                      },
+                      "type": "token",
+                    },
                   ],
                   "closeParen": ")",
-                  "hasWhitespaceBefore": false,
                   "openParen": "(",
                   "type": "parenthesis",
                 },
               ],
               "closeParen": ")",
-              "hasWhitespaceBefore": false,
               "openParen": "(",
               "type": "parenthesis",
             },


### PR DESCRIPTION
The function calls are still detected based on whether there's empty space between an identifier and `(`. That's far from correct, but that's how the current code works.

Also dropping some incorrect handing of `[..]`, `{..}`, `$`-prefix and backquotes syntax from operator formatting code. All these are handled elsewhere:

- `{..}` and `[..]` get detected as Parenthesis blocks.
- `$`-prefixes are part of identifiers in dialects that support them.
- backquoted identifiers get detected as identifiers in dialects that support them.