### PR TITLE
8.0: Refactor WhitespaceBuilder to avoid string-manipulation

### DIFF
--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -91,21 +91,20 @@ export default class ExpressionFormatter {
   private formatParenthesis(node: Parenthesis) {
     const inline = this.inlineBlock.isInlineBlock(node);
 
-    const formattedSql = new ExpressionFormatter(this.cfg, this.params, {
+    const subLayout = new ExpressionFormatter(this.cfg, this.params, {
       inline,
     })
       .format(node.children)
-      .toString()
-      .trimEnd();
+      .toLayout();
 
     if (inline) {
-      this.query.add(node.openParen, formattedSql, node.closeParen, WS.SPACE);
+      this.query.add(node.openParen, ...subLayout, WS.NO_SPACE, node.closeParen, WS.SPACE);
     } else {
-      this.query.add(node.openParen);
+      this.query.add(node.openParen, WS.NEWLINE);
 
-      formattedSql.split(/\n/).forEach(line => {
-        this.query.add(WS.NEWLINE, WS.INDENT, WS.SINGLE_INDENT, line);
-      });
+      this.indentation.increaseBlockLevel();
+      this.query.addLayout(subLayout);
+      this.indentation.decreaseBlockLevel();
 
       this.query.add(WS.NEWLINE, WS.INDENT, node.closeParen, WS.SPACE);
     }

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -125,22 +125,17 @@ export default class ExpressionFormatter {
   }
 
   private formatClause(node: Clause) {
-    const formattedSql = new ExpressionFormatter(this.cfg, this.params, { inline: this.inline })
+    const subLayout = new ExpressionFormatter(this.cfg, this.params, { inline: this.inline })
       .format(node.children)
-      .toString()
-      .trimEnd();
+      .toLayout();
 
     this.indentation.decreaseTopLevel();
-    this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken));
+    this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
     this.indentation.increaseTopLevel();
 
-    if (formattedSql.length > 0) {
-      formattedSql.split(/\n/).forEach(line => {
-        this.query.add(WS.NEWLINE, WS.INDENT, line);
-      });
+    if (subLayout.length > 0) {
+      this.query.addLayout(subLayout);
     }
-
-    this.query.add(WS.SPACE);
   }
 
   private formatBinaryClause(node: BinaryClause) {

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -229,12 +229,20 @@ export default class ExpressionFormatter {
 
   /** Formats a block comment onto query */
   private formatBlockComment(token: Token) {
-    this.query.add(WS.NEWLINE, WS.INDENT, this.indentComment(token.value), WS.NEWLINE, WS.INDENT);
+    this.splitBlockComment(token.value).forEach(line => {
+      this.query.add(WS.NEWLINE, WS.INDENT, line);
+    });
+    this.query.add(WS.NEWLINE, WS.INDENT);
   }
 
-  /** Aligns comment to current indentation level */
-  private indentComment(comment: string): string {
-    return comment.replace(/\n[ \t]*/gu, '\n' + this.indentation.getIndent() + ' ');
+  private splitBlockComment(comment: string): string[] {
+    return comment.split(/\n/).map(line => {
+      if (/^\s*\*/.test(line)) {
+        return ' ' + line.replace(/^\s*/, '');
+      } else {
+        return line.replace(/^\s*/, '');
+      }
+    });
   }
 
   private formatJoin(token: Token) {

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -133,9 +133,7 @@ export default class ExpressionFormatter {
     this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
     this.indentation.increaseTopLevel();
 
-    if (subLayout.length > 0) {
-      this.query.addLayout(subLayout);
-    }
+    this.query.addLayout(subLayout);
   }
 
   private formatBinaryClause(node: BinaryClause) {
@@ -146,11 +144,7 @@ export default class ExpressionFormatter {
     this.indentation.decreaseTopLevel();
     this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
 
-    if (subLayout.length > 0) {
-      this.query.addLayout(subLayout);
-    }
-
-    this.query.add(WS.NEWLINE, WS.INDENT);
+    this.query.addLayout(subLayout);
   }
 
   private formatLimitClause(node: LimitClause) {

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -139,18 +139,15 @@ export default class ExpressionFormatter {
   }
 
   private formatBinaryClause(node: BinaryClause) {
-    const formattedSql = new ExpressionFormatter(this.cfg, this.params, { inline: this.inline })
+    const subLayout = new ExpressionFormatter(this.cfg, this.params, { inline: this.inline })
       .format(node.children)
-      .toString()
-      .trimEnd();
+      .toLayout();
 
     this.indentation.decreaseTopLevel();
-    this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken));
+    this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
 
-    if (formattedSql.length > 0) {
-      formattedSql.split(/\n/).forEach(line => {
-        this.query.add(WS.NEWLINE, WS.INDENT, line);
-      });
+    if (subLayout.length > 0) {
+      this.query.addLayout(subLayout);
     }
 
     this.query.add(WS.NEWLINE, WS.INDENT);

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -270,9 +270,6 @@ export default class ExpressionFormatter {
     if (token.value === ',') {
       this.formatComma(token);
       return;
-    } else if (token.value === ';') {
-      this.formatQuerySeparator(token);
-      return;
     } else if (token.value === ':') {
       this.query.add(WS.NO_SPACE, this.show(token), WS.SPACE);
       return;
@@ -330,14 +327,6 @@ export default class ExpressionFormatter {
       this.query.add(WS.NO_SPACE, this.show(token), WS.NEWLINE, WS.INDENT);
     } else {
       this.query.add(WS.NO_SPACE, this.show(token), WS.SPACE);
-    }
-  }
-
-  private formatQuerySeparator(token: Token) {
-    if (this.cfg.newlineBeforeSemicolon) {
-      this.query.add(WS.NEWLINE, this.show(token));
-    } else {
-      this.query.add(WS.NO_SPACE, this.show(token));
     }
   }
 

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -40,7 +40,7 @@ export default class ExpressionFormatter {
     this.query = new WhitespaceBuilder(this.indentation);
   }
 
-  public format(nodes: AstNode[]): string {
+  public format(nodes: AstNode[]): WhitespaceBuilder {
     this.nodes = nodes;
 
     for (this.index = 0; this.index < this.nodes.length; this.index++) {
@@ -75,7 +75,7 @@ export default class ExpressionFormatter {
           break;
       }
     }
-    return this.query.toString();
+    return this.query;
   }
 
   private formatFunctionCall(node: FunctionCall) {
@@ -95,6 +95,7 @@ export default class ExpressionFormatter {
       inline,
     })
       .format(node.children)
+      .toString()
       .trimEnd();
 
     if (inline) {
@@ -126,6 +127,7 @@ export default class ExpressionFormatter {
   private formatClause(node: Clause) {
     const formattedSql = new ExpressionFormatter(this.cfg, this.params, { inline: this.inline })
       .format(node.children)
+      .toString()
       .trimEnd();
 
     this.indentation.decreaseTopLevel();
@@ -144,6 +146,7 @@ export default class ExpressionFormatter {
   private formatBinaryClause(node: BinaryClause) {
     const formattedSql = new ExpressionFormatter(this.cfg, this.params, { inline: this.inline })
       .format(node.children)
+      .toString()
       .trimEnd();
 
     this.indentation.decreaseTopLevel();

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -54,8 +54,21 @@ export default class Formatter {
 
   private formatAst(statements: Statement[]): string {
     return statements
-      .map(stat => new ExpressionFormatter(this.cfg, this.params).format(stat.children))
+      .map(stat => this.formatStatement(stat))
       .join('\n'.repeat(this.cfg.linesBetweenQueries + 1));
+  }
+
+  private formatStatement(statement: Statement): string {
+    const sql = new ExpressionFormatter(this.cfg, this.params).format(statement.children);
+    if (!statement.hasSemicolon) {
+      return sql;
+    } else if (sql.trimEnd() === '') {
+      return ';';
+    } else if (this.cfg.newlineBeforeSemicolon) {
+      return sql.trimEnd() + '\n;';
+    } else {
+      return sql.trimEnd() + ';';
+    }
   }
 
   private postFormat(query: string): string {

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -8,6 +8,7 @@ import ExpressionFormatter from './ExpressionFormatter';
 import { indentString } from './config';
 import AliasAs from './AliasAs';
 import { Statement } from './ast';
+import { WS } from './WhitespaceBuilder';
 
 /** Main formatter class that produces a final output string from list of tokens */
 export default class Formatter {
@@ -59,18 +60,15 @@ export default class Formatter {
   }
 
   private formatStatement(statement: Statement): string {
-    const sql = new ExpressionFormatter(this.cfg, this.params)
-      .format(statement.children)
-      .toString();
+    const wsBuilder = new ExpressionFormatter(this.cfg, this.params).format(statement.children);
     if (!statement.hasSemicolon) {
-      return sql;
-    } else if (sql.trimEnd() === '') {
-      return ';';
+      // do nothing
     } else if (this.cfg.newlineBeforeSemicolon) {
-      return sql.trimEnd() + '\n;';
+      wsBuilder.add(WS.NEWLINE, ';');
     } else {
-      return sql.trimEnd() + ';';
+      wsBuilder.add(WS.NO_SPACE, ';');
     }
+    return wsBuilder.toString();
   }
 
   private postFormat(query: string): string {

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -59,7 +59,9 @@ export default class Formatter {
   }
 
   private formatStatement(statement: Statement): string {
-    const sql = new ExpressionFormatter(this.cfg, this.params).format(statement.children);
+    const sql = new ExpressionFormatter(this.cfg, this.params)
+      .format(statement.children)
+      .toString();
     if (!statement.hasSemicolon) {
       return sql;
     } else if (sql.trimEnd() === '') {

--- a/src/core/Parser.ts
+++ b/src/core/Parser.ts
@@ -15,8 +15,7 @@ import {
 import { EOF_TOKEN, type Token, TokenType, isToken } from './token';
 
 /**
- * A rudimentary parser that slices token stream into list of SQL statements
- * and groups of parenthesis.
+ * A simple parser that creates a very rudimentary syntax tree.
  */
 export default class Parser {
   private index = 0;
@@ -36,11 +35,11 @@ export default class Parser {
     const children: AstNode[] = [];
     while (true) {
       if (this.look().value === ';') {
-        children.push(this.nextTokenNode());
-        return { type: 'statement', children };
+        this.next();
+        return { type: 'statement', children, hasSemicolon: true };
       } else if (this.look().type === TokenType.EOF) {
         if (children.length > 0) {
-          return { type: 'statement', children };
+          return { type: 'statement', children, hasSemicolon: false };
         } else {
           return undefined;
         }

--- a/src/core/WhitespaceBuilder.ts
+++ b/src/core/WhitespaceBuilder.ts
@@ -20,7 +20,7 @@ export enum WS {
  * Now it's storing items to array and builds the string only in the end.
  */
 export default class WhitespaceBuilder {
-  private query: (WS.SPACE | WS.SINGLE_INDENT | WS.NEWLINE | string)[] = [];
+  private layout: (WS.SPACE | WS.SINGLE_INDENT | WS.NEWLINE | string)[] = [];
 
   constructor(private indentation: Indentation) {}
 
@@ -31,7 +31,7 @@ export default class WhitespaceBuilder {
     for (const item of items) {
       switch (item) {
         case WS.SPACE:
-          this.query.push(WS.SPACE);
+          this.layout.push(WS.SPACE);
           break;
         case WS.NO_SPACE:
           this.trimHorizontalWhitespace();
@@ -45,33 +45,33 @@ export default class WhitespaceBuilder {
           break;
         case WS.INDENT:
           for (let i = 0; i < this.indentation.getLevel(); i++) {
-            this.query.push(WS.SINGLE_INDENT);
+            this.layout.push(WS.SINGLE_INDENT);
           }
           break;
         case WS.SINGLE_INDENT:
-          this.query.push(WS.SINGLE_INDENT);
+          this.layout.push(WS.SINGLE_INDENT);
           break;
         default:
-          this.query.push(item);
+          this.layout.push(item);
       }
     }
   }
 
   private trimHorizontalWhitespace() {
-    while (isHorizontalWhitespace(last(this.query))) {
-      this.query.pop();
+    while (isHorizontalWhitespace(last(this.layout))) {
+      this.layout.pop();
     }
   }
 
   private trimAllWhitespace() {
-    while (isWhitespace(last(this.query))) {
-      this.query.pop();
+    while (isWhitespace(last(this.layout))) {
+      this.layout.pop();
     }
   }
 
   private addNewline() {
-    if (this.query.length > 0 && last(this.query) !== WS.NEWLINE) {
-      this.query.push(WS.NEWLINE);
+    if (this.layout.length > 0 && last(this.layout) !== WS.NEWLINE) {
+      this.layout.push(WS.NEWLINE);
     }
   }
 
@@ -79,7 +79,7 @@ export default class WhitespaceBuilder {
    * Returns the final SQL string.
    */
   public toString(): string {
-    return this.query.map(item => this.itemToString(item)).join('');
+    return this.layout.map(item => this.itemToString(item)).join('');
   }
 
   private itemToString(item: WS | string) {

--- a/src/core/WhitespaceBuilder.ts
+++ b/src/core/WhitespaceBuilder.ts
@@ -27,6 +27,20 @@ export default class WhitespaceBuilder {
   constructor(private indentation: Indentation) {}
 
   /**
+   * Appands an already constructed sub-layout
+   * and indents each line in it by current level of indentation
+   */
+  public addLayout(layout: LayoutItem[]) {
+    this.addIndentation();
+    layout.forEach((item, i) => {
+      this.layout.push(item);
+      if (item === WS.NEWLINE && i < layout.length - 1) {
+        this.addIndentation();
+      }
+    });
+  }
+
+  /**
    * Appends token strings and whitespace modifications to SQL string.
    */
   public add(...items: (WS | string)[]) {
@@ -46,9 +60,7 @@ export default class WhitespaceBuilder {
           this.trimAllWhitespace();
           break;
         case WS.INDENT:
-          for (let i = 0; i < this.indentation.getLevel(); i++) {
-            this.layout.push(WS.SINGLE_INDENT);
-          }
+          this.addIndentation();
           break;
         case WS.SINGLE_INDENT:
           this.layout.push(WS.SINGLE_INDENT);
@@ -77,11 +89,24 @@ export default class WhitespaceBuilder {
     }
   }
 
+  private addIndentation() {
+    for (let i = 0; i < this.indentation.getLevel(); i++) {
+      this.layout.push(WS.SINGLE_INDENT);
+    }
+  }
+
   /**
    * Returns the final SQL string.
    */
   public toString(): string {
     return this.layout.map(item => this.itemToString(item)).join('');
+  }
+
+  /**
+   * Returns the constructed whitespace layout structure.
+   */
+  public toLayout(): LayoutItem[] {
+    return this.layout;
   }
 
   private itemToString(item: LayoutItem): string {

--- a/src/core/WhitespaceBuilder.ts
+++ b/src/core/WhitespaceBuilder.ts
@@ -12,6 +12,8 @@ export enum WS {
   SINGLE_INDENT = 6, // Adds whitespace for single indentation step
 }
 
+export type LayoutItem = WS.SPACE | WS.SINGLE_INDENT | WS.NEWLINE | string;
+
 /**
  * API for constructing SQL string (especially the whitespace part).
  *
@@ -20,7 +22,7 @@ export enum WS {
  * Now it's storing items to array and builds the string only in the end.
  */
 export default class WhitespaceBuilder {
-  private layout: (WS.SPACE | WS.SINGLE_INDENT | WS.NEWLINE | string)[] = [];
+  private layout: LayoutItem[] = [];
 
   constructor(private indentation: Indentation) {}
 
@@ -82,7 +84,7 @@ export default class WhitespaceBuilder {
     return this.layout.map(item => this.itemToString(item)).join('');
   }
 
-  private itemToString(item: WS | string) {
+  private itemToString(item: LayoutItem): string {
     switch (item) {
       case WS.SPACE:
         return ' ';

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -3,6 +3,7 @@ import { Token } from './token';
 export type Statement = {
   type: 'statement';
   children: AstNode[];
+  hasSemicolon: boolean;
 };
 
 export type Clause = {

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -56,8 +56,7 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
     `);
   });
 
-  // XXX: Temporarily disabled. Fix this!
-  it.skip('formats line comments followed by semicolon', () => {
+  it('formats line comments followed by semicolon', () => {
     expect(
       format(`
       SELECT a FROM b

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -36,16 +36,8 @@ describe('Parser', () => {
               },
               "type": "token",
             },
-            Object {
-              "token": Object {
-                "text": ";",
-                "type": "OPERATOR",
-                "value": ";",
-                "whitespaceBefore": "",
-              },
-              "type": "token",
-            },
           ],
+          "hasSemicolon": true,
           "type": "statement",
         },
         Object {
@@ -60,6 +52,7 @@ describe('Parser', () => {
               "type": "token",
             },
           ],
+          "hasSemicolon": false,
           "type": "statement",
         },
       ]
@@ -108,6 +101,7 @@ describe('Parser', () => {
               "type": "clause",
             },
           ],
+          "hasSemicolon": false,
           "type": "statement",
         },
       ]
@@ -172,6 +166,7 @@ describe('Parser', () => {
               "type": "clause",
             },
           ],
+          "hasSemicolon": false,
           "type": "statement",
         },
       ]
@@ -254,6 +249,7 @@ describe('Parser', () => {
               "type": "clause",
             },
           ],
+          "hasSemicolon": false,
           "type": "statement",
         },
       ]
@@ -312,16 +308,8 @@ describe('Parser', () => {
               },
               "type": "clause",
             },
-            Object {
-              "token": Object {
-                "text": ";",
-                "type": "OPERATOR",
-                "value": ";",
-                "whitespaceBefore": "",
-              },
-              "type": "token",
-            },
           ],
+          "hasSemicolon": true,
           "type": "statement",
         },
       ]
@@ -349,6 +337,7 @@ describe('Parser', () => {
               "type": "limit_clause",
             },
           ],
+          "hasSemicolon": false,
           "type": "statement",
         },
       ]
@@ -382,6 +371,7 @@ describe('Parser', () => {
               "type": "limit_clause",
             },
           ],
+          "hasSemicolon": false,
           "type": "statement",
         },
       ]
@@ -408,6 +398,7 @@ describe('Parser', () => {
               "type": "clause",
             },
           ],
+          "hasSemicolon": false,
           "type": "statement",
         },
       ]


### PR DESCRIPTION
Instead of using `WhitespaceBuilder.toString()` method to get the result of formatting a sub-expression (e.g. a Parenthesis block) and then doing string-manipulation to append it to current formatting state, the `WhitespaceBuilder` now exposes two new methods:

- `toLayout()` returns the internal representation of formatted SQL,
- `addLayout()` takes the output from the above method and appends it to current formatting context, adding indentation as needed to each line.

Additionally the `Statement` node no more contains semicolon token inside its children, but instead has a `hasSemicolon` field.