### PR TITLE
8.0: Restore indentStyle support

### DIFF
--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -253,7 +253,14 @@ export default class ExpressionFormatter {
   }
 
   private formatJoin(token: Token) {
-    this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
+    if (isTabularStyle(this.cfg)) {
+      // in tabular style JOINs are at the same level as clauses
+      this.query.indentation.decreaseTopLevel();
+      this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
+      this.query.indentation.increaseTopLevel();
+    } else {
+      this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
+    }
   }
 
   /**
@@ -304,7 +311,14 @@ export default class ExpressionFormatter {
    */
   private formatLogicalOperator(token: Token) {
     if (this.cfg.logicalOperatorNewline === 'before') {
-      this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
+      if (isTabularStyle(this.cfg)) {
+        // In tabular style AND/OR is placed on the same level as clauses
+        this.query.indentation.decreaseTopLevel();
+        this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
+        this.query.indentation.increaseTopLevel();
+      } else {
+        this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
+      }
     } else {
       this.query.add(this.show(token), WS.NEWLINE, WS.INDENT);
     }

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -99,6 +99,7 @@ export default class ExpressionFormatter {
       this.query.add(node.openParen, WS.NEWLINE);
 
       this.indentation.increaseBlockLevel();
+      this.query.add(WS.INDENT);
       this.query.addLayout(subLayout);
       this.indentation.decreaseBlockLevel();
 
@@ -126,6 +127,7 @@ export default class ExpressionFormatter {
     this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
     this.indentation.increaseTopLevel();
 
+    this.query.add(WS.INDENT);
     this.query.addLayout(subLayout);
   }
 
@@ -135,6 +137,7 @@ export default class ExpressionFormatter {
     this.indentation.decreaseTopLevel();
     this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
 
+    this.query.add(WS.INDENT);
     this.query.addLayout(subLayout);
   }
 

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -20,6 +20,12 @@ import { indentString, isTabularStyle } from './config';
 import WhitespaceBuilder, { LayoutItem, WS } from './WhitespaceBuilder';
 import toTabularFormat, { isTabularToken } from './tabularStyle';
 
+interface ExpressionFormatterParams {
+  cfg: FormatOptions;
+  params: Params;
+  inline?: boolean;
+}
+
 /** Formats a generic SQL expression */
 export default class ExpressionFormatter {
   private cfg: FormatOptions;
@@ -32,7 +38,7 @@ export default class ExpressionFormatter {
   private nodes: AstNode[] = [];
   private index = -1;
 
-  constructor(cfg: FormatOptions, params: Params, { inline = false }: { inline?: boolean } = {}) {
+  constructor({ cfg, params, inline = false }: ExpressionFormatterParams) {
     this.cfg = cfg;
     this.inline = inline;
     this.indentation = new Indentation(indentString(cfg));
@@ -179,7 +185,9 @@ export default class ExpressionFormatter {
   }
 
   private formatSubExpression(nodes: AstNode[], inline = this.inline): LayoutItem[] {
-    return new ExpressionFormatter(this.cfg, this.params, { inline }).format(nodes).toLayout();
+    return new ExpressionFormatter({ cfg: this.cfg, params: this.params, inline })
+      .format(nodes)
+      .toLayout();
   }
 
   private formatToken(token: Token): void {

--- a/src/core/ExpressionFormatter.ts
+++ b/src/core/ExpressionFormatter.ts
@@ -29,7 +29,6 @@ interface ExpressionFormatterParams {
 /** Formats a generic SQL expression */
 export default class ExpressionFormatter {
   private cfg: FormatOptions;
-  private indentation: Indentation;
   private inlineBlock: InlineBlock;
   private params: Params;
   private query: WhitespaceBuilder;
@@ -41,10 +40,9 @@ export default class ExpressionFormatter {
   constructor({ cfg, params, inline = false }: ExpressionFormatterParams) {
     this.cfg = cfg;
     this.inline = inline;
-    this.indentation = new Indentation(indentString(cfg));
     this.inlineBlock = new InlineBlock(this.cfg.expressionWidth);
     this.params = params;
-    this.query = new WhitespaceBuilder(this.indentation);
+    this.query = new WhitespaceBuilder(new Indentation(indentString(cfg)));
   }
 
   public format(nodes: AstNode[]): WhitespaceBuilder {
@@ -109,10 +107,10 @@ export default class ExpressionFormatter {
         this.query.add(WS.INDENT);
         this.query.addLayout(subLayout);
       } else {
-        this.indentation.increaseBlockLevel();
+        this.query.indentation.increaseBlockLevel();
         this.query.add(WS.INDENT);
         this.query.addLayout(subLayout);
-        this.indentation.decreaseBlockLevel();
+        this.query.indentation.decreaseBlockLevel();
       }
 
       this.query.add(WS.NEWLINE, WS.INDENT, node.closeParen, WS.SPACE);
@@ -135,13 +133,13 @@ export default class ExpressionFormatter {
   private formatClause(node: Clause) {
     const subLayout = this.formatSubExpression(node.children);
 
-    this.indentation.decreaseTopLevel();
+    this.query.indentation.decreaseTopLevel();
     if (isTabularStyle(this.cfg)) {
       this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.SPACE);
     } else {
       this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
     }
-    this.indentation.increaseTopLevel();
+    this.query.indentation.increaseTopLevel();
 
     if (!isTabularStyle(this.cfg)) {
       this.query.add(WS.INDENT);
@@ -152,7 +150,7 @@ export default class ExpressionFormatter {
   private formatBinaryClause(node: BinaryClause) {
     const subLayout = this.formatSubExpression(node.children);
 
-    this.indentation.decreaseTopLevel();
+    this.query.indentation.decreaseTopLevel();
     this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
 
     this.query.add(WS.INDENT);
@@ -160,9 +158,9 @@ export default class ExpressionFormatter {
   }
 
   private formatLimitClause(node: LimitClause) {
-    this.indentation.decreaseTopLevel();
+    this.query.indentation.decreaseTopLevel();
     this.query.add(WS.NEWLINE, WS.INDENT, this.show(node.limitToken));
-    this.indentation.increaseTopLevel();
+    this.query.indentation.increaseTopLevel();
 
     if (node.offsetToken) {
       this.query.add(
@@ -313,7 +311,7 @@ export default class ExpressionFormatter {
   }
 
   private formatCaseStart(token: Token) {
-    this.indentation.increaseBlockLevel();
+    this.query.indentation.increaseBlockLevel();
     this.query.add(this.show(token), WS.NEWLINE, WS.INDENT);
   }
 
@@ -322,7 +320,7 @@ export default class ExpressionFormatter {
   }
 
   private formatMultilineBlockEnd(token: Token) {
-    this.indentation.decreaseBlockLevel();
+    this.query.indentation.decreaseBlockLevel();
 
     this.query.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
   }

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -60,7 +60,9 @@ export default class Formatter {
   }
 
   private formatStatement(statement: Statement): string {
-    const wsBuilder = new ExpressionFormatter(this.cfg, this.params).format(statement.children);
+    const wsBuilder = new ExpressionFormatter({ cfg: this.cfg, params: this.params }).format(
+      statement.children
+    );
     if (!statement.hasSemicolon) {
       // do nothing
     } else if (this.cfg.newlineBeforeSemicolon) {

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -8,7 +8,8 @@ import ExpressionFormatter from './ExpressionFormatter';
 import { indentString } from './config';
 import AliasAs from './AliasAs';
 import { Statement } from './ast';
-import { WS } from './WhitespaceBuilder';
+import WhitespaceBuilder, { WS } from './WhitespaceBuilder';
+import Indentation from './Indentation';
 
 /** Main formatter class that produces a final output string from list of tokens */
 export default class Formatter {
@@ -60,9 +61,12 @@ export default class Formatter {
   }
 
   private formatStatement(statement: Statement): string {
-    const wsBuilder = new ExpressionFormatter({ cfg: this.cfg, params: this.params }).format(
-      statement.children
-    );
+    const wsBuilder = new ExpressionFormatter({
+      cfg: this.cfg,
+      params: this.params,
+      query: new WhitespaceBuilder(new Indentation(indentString(this.cfg))),
+    }).format(statement.children);
+
     if (!statement.hasSemicolon) {
       // do nothing
     } else if (this.cfg.newlineBeforeSemicolon) {

--- a/src/core/WhitespaceBuilder.ts
+++ b/src/core/WhitespaceBuilder.ts
@@ -27,20 +27,6 @@ export default class WhitespaceBuilder {
   constructor(public indentation: Indentation) {}
 
   /**
-   * Appands an already constructed sub-layout
-   * and indents each line in it by current level of indentation
-   * (except for the first line)
-   */
-  public addLayout(layout: LayoutItem[]) {
-    layout.forEach((item, i) => {
-      this.layout.push(item);
-      if (item === WS.NEWLINE && i < layout.length - 1) {
-        this.addIndentation();
-      }
-    });
-  }
-
-  /**
    * Appends token strings and whitespace modifications to SQL string.
    */
   public add(...items: (WS | string)[]) {
@@ -100,13 +86,6 @@ export default class WhitespaceBuilder {
    */
   public toString(): string {
     return this.layout.map(item => this.itemToString(item)).join('');
-  }
-
-  /**
-   * Returns the constructed whitespace layout structure.
-   */
-  public toLayout(): LayoutItem[] {
-    return this.layout;
   }
 
   private itemToString(item: LayoutItem): string {

--- a/src/core/WhitespaceBuilder.ts
+++ b/src/core/WhitespaceBuilder.ts
@@ -24,7 +24,7 @@ export type LayoutItem = WS.SPACE | WS.SINGLE_INDENT | WS.NEWLINE | string;
 export default class WhitespaceBuilder {
   private layout: LayoutItem[] = [];
 
-  constructor(private indentation: Indentation) {}
+  constructor(public indentation: Indentation) {}
 
   /**
    * Appands an already constructed sub-layout

--- a/src/core/WhitespaceBuilder.ts
+++ b/src/core/WhitespaceBuilder.ts
@@ -29,9 +29,9 @@ export default class WhitespaceBuilder {
   /**
    * Appands an already constructed sub-layout
    * and indents each line in it by current level of indentation
+   * (except for the first line)
    */
   public addLayout(layout: LayoutItem[]) {
-    this.addIndentation();
     layout.forEach((item, i) => {
       this.layout.push(item);
       if (item === WS.NEWLINE && i < layout.length - 1) {

--- a/src/core/tabularStyle.ts
+++ b/src/core/tabularStyle.ts
@@ -1,4 +1,5 @@
 import type { IndentStyle } from 'src/types';
+import { Token, TokenType } from './token';
 
 /**
  * When tabular style enabled,
@@ -22,4 +23,17 @@ export default function toTabularFormat(tokenText: string, indentStyle: IndentSt
   }
 
   return tokenText + ['', ...tail].join(' ');
+}
+
+/**
+ * True when the token can be formatted in tabular style
+ */
+export function isTabularToken(token: Token): boolean {
+  return (
+    token.type === TokenType.RESERVED_LOGICAL_OPERATOR ||
+    token.type === TokenType.RESERVED_DEPENDENT_CLAUSE ||
+    token.type === TokenType.RESERVED_COMMAND ||
+    token.type === TokenType.RESERVED_BINARY_COMMAND ||
+    token.type === TokenType.RESERVED_JOIN
+  );
 }

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -9,6 +9,7 @@ import supportsUseTabs from './options/useTabs';
 import supportsAliasAs from './options/aliasAs';
 import supportsExpressionWidth from './options/expressionWidth';
 import supportsKeywordCase from './options/keywordCase';
+import supportsIndentStyle from './options/indentStyle';
 import supportsCommaPosition from './options/commaPosition';
 import supportsLinesBetweenQueries from './options/linesBetweenQueries';
 import supportsNewlineBeforeSemicolon from './options/newlineBeforeSemicolon';
@@ -27,7 +28,7 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
   supportsTabWidth(format);
   supportsUseTabs(format);
   supportsKeywordCase(format);
-  // supportsIndentStyle(format); // XXX: Feature is disabled for now
+  supportsIndentStyle(format);
   supportsLinesBetweenQueries(format);
   // supportsMultilineLists(format); // XXX: Feature is disabled for now
   supportsExpressionWidth(format);

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -81,7 +81,7 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
     ).toBe(dedent`
       SELECT
         a --comment
-        ,
+      ,
         b
     `);
   });

--- a/test/features/operators.ts
+++ b/test/features/operators.ts
@@ -20,7 +20,7 @@ export default function supportsOperators(
   });
 
   logicalOperators.forEach(op => {
-    describe(`supports ${op} operator`, () => {
+    it(`supports ${op} operator`, () => {
       const result = format(`SELECT true ${op} false AS foo;`);
       expect(result).toBe(dedent`
         SELECT

--- a/test/n1ql.test.ts
+++ b/test/n1ql.test.ts
@@ -101,7 +101,7 @@ describe('N1qlFormatter', () => {
         'Elinor_33313792'
       NEST
         orders_with_users orders ON KEYS ARRAY s.order_id FOR s IN usr.shipped_order_history
-        END;
+      END;
     `);
   });
 

--- a/test/options/indentStyle.ts
+++ b/test/options/indentStyle.ts
@@ -47,9 +47,9 @@ export default function supportsIndentStyle(format: FormatFn) {
                             column5
                   FROM      table1
                   ) a
-        JOIN      table2 b ON a.column5 = b.column5
+                  JOIN      table2 b ON a.column5 = b.column5
         WHERE     column6
-        AND       column7
+                  AND       column7
         GROUP BY  column4;
       `);
     });
@@ -73,12 +73,12 @@ export default function supportsIndentStyle(format: FormatFn) {
         UNION     DISTINCT
         SELECT    *
         FROM      b
-        LEFT      OUTER JOIN c;
+                  LEFT      OUTER JOIN c;
       `);
     });
 
-    // TODO: Disabled temporarily
-    it.skip('handles multiple levels of nested queries', () => {
+    // TODO: This looks pretty bad at the moment
+    it('handles multiple levels of nested queries', () => {
       expect(
         format(
           'SELECT age FROM (SELECT fname, lname, age FROM (SELECT fname, lname FROM persons) JOIN (SELECT age FROM ages)) as mytable;',
@@ -97,7 +97,7 @@ export default function supportsIndentStyle(format: FormatFn) {
                                       lname
                             FROM      persons
                             )
-                  JOIN      (
+                            JOIN      (
                             SELECT    age
                             FROM      ages
                             )
@@ -134,9 +134,9 @@ export default function supportsIndentStyle(format: FormatFn) {
           '                    column5',
           '               FROM table1',
           '          ) a',
-          '     JOIN table2 b ON a.column5 = b.column5',
+          '               JOIN table2 b ON a.column5 = b.column5',
           '    WHERE column6',
-          '      AND column7',
+          '                AND column7',
           ' GROUP BY column4;',
         ].join('\n')
       );
@@ -162,7 +162,7 @@ export default function supportsIndentStyle(format: FormatFn) {
           '    UNION DISTINCT',
           '   SELECT *',
           '     FROM b',
-          '     LEFT OUTER JOIN c;',
+          '               LEFT OUTER JOIN c;',
         ].join('\n')
       );
     });

--- a/test/options/indentStyle.ts
+++ b/test/options/indentStyle.ts
@@ -47,9 +47,9 @@ export default function supportsIndentStyle(format: FormatFn) {
                             column5
                   FROM      table1
                   ) a
-                  JOIN      table2 b ON a.column5 = b.column5
+        JOIN      table2 b ON a.column5 = b.column5
         WHERE     column6
-                  AND       column7
+        AND       column7
         GROUP BY  column4;
       `);
     });
@@ -73,11 +73,10 @@ export default function supportsIndentStyle(format: FormatFn) {
         UNION     DISTINCT
         SELECT    *
         FROM      b
-                  LEFT      OUTER JOIN c;
+        LEFT      OUTER JOIN c;
       `);
     });
 
-    // TODO: This looks pretty bad at the moment
     it('handles multiple levels of nested queries', () => {
       expect(
         format(
@@ -97,7 +96,7 @@ export default function supportsIndentStyle(format: FormatFn) {
                                       lname
                             FROM      persons
                             )
-                            JOIN      (
+                  JOIN      (
                             SELECT    age
                             FROM      ages
                             )
@@ -134,9 +133,9 @@ export default function supportsIndentStyle(format: FormatFn) {
           '                    column5',
           '               FROM table1',
           '          ) a',
-          '               JOIN table2 b ON a.column5 = b.column5',
+          '     JOIN table2 b ON a.column5 = b.column5',
           '    WHERE column6',
-          '                AND column7',
+          '      AND column7',
           ' GROUP BY column4;',
         ].join('\n')
       );
@@ -162,7 +161,7 @@ export default function supportsIndentStyle(format: FormatFn) {
           '    UNION DISTINCT',
           '   SELECT *',
           '     FROM b',
-          '               LEFT OUTER JOIN c;',
+          '     LEFT OUTER JOIN c;',
         ].join('\n')
       );
     });

--- a/test/options/tabulateAlias.ts
+++ b/test/options/tabulateAlias.ts
@@ -110,7 +110,7 @@ export default function supportsTabulateAlias(format: FormatFn) {
     `);
   });
 
-  it.skip('works together with indentStyle:tabularLeft', () => {
+  it('works together with indentStyle:tabularLeft', () => {
     const result = format(
       dedent`SELECT alpha AS alp, MAX(beta), epsilon AS E FROM ( SELECT mu AS m, iota AS io FROM gamma );`,
       { indentStyle: 'tabularLeft', tabulateAlias: true }
@@ -128,7 +128,7 @@ export default function supportsTabulateAlias(format: FormatFn) {
     `);
   });
 
-  it.skip('works together with indentStyle:tabularRight', () => {
+  it('works together with indentStyle:tabularRight', () => {
     const result = format(
       dedent`SELECT alpha AS alp, MAX(beta), epsilon AS E FROM ( SELECT mu AS m, iota AS io FROM gamma );`,
       { indentStyle: 'tabularRight', tabulateAlias: true }

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -54,7 +54,7 @@ describe('SqlFormatter', () => {
     ).toBe(dedent`
       SELECT
         @ name,
-        : bar
+      : bar
       FROM
         { foo };
     `);


### PR DESCRIPTION
Currently having some trouble restoring the original style.

Previously everything was just a stream of tokens, so you could indent things however you pleased, but now the following SQL:

```sql
SELECT *
FROM foo JOIN bar
```

gets parsed into structure like:

```js
[
  {type: "clause", name: "SELECT", children: ["*"]},
  {type: "clause", name: "FROM", children: ["foo", "JOIN", "bar"]},
]
```

and each array of children gets formatted in isolation, assuming that they are all indented 1 step more than the preceding `SELECT` or `FROM`. But that doesn't hold true for the formatting of `JOIN` in tabular style - there we would want to indent it at the same level as `SELECT`.

I see a few ways here:

- change the Parser to output JOIN blocks to the same level as clauses. Don't really like that. The AST shouldn't depend  on our formatting needs.
- change the formatting logic to eliminate this limit. Like instead of re-indenting the formatted sub-expression, passing the current indentation to the sub-expression formatter.
