### PR TITLE
Print warning when params values aren't all strings

### DIFF
--- a/docs/params.md
+++ b/docs/params.md
@@ -6,7 +6,7 @@ This option is designed to be used through API (though nothing really prevents u
 
 ## Option value
 
-- `Array` of strings and/or numbers for position placeholders.
+- `Array` of strings for position placeholders.
 - `Object` of name-value pairs for named (and indexed) placeholders.
 
 Note: The escaping of values must be handled by user of the API.

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -14,6 +14,7 @@ import TSqlFormatter from 'src/languages/tsql.formatter';
 
 import type { FormatOptions } from './types';
 import { isNumber } from './utils';
+import { ParamItems } from './core/Params';
 
 export const formatters = {
   bigquery: BigQueryFormatter,
@@ -110,7 +111,17 @@ function validateConfig(cfg: FormatFnOptions): FormatFnOptions {
     );
   }
 
+  if (cfg.params && !validateParams(cfg.params)) {
+    // eslint-disable-next-line no-console
+    console.warn('WARNING: All "params" option values should be strings.');
+  }
+
   return cfg;
+}
+
+function validateParams(params: ParamItems | string[]): boolean {
+  const paramValues = params instanceof Array ? params : Object.values(params);
+  return paramValues.every(p => typeof p === 'string');
 }
 
 export type FormatFn = typeof format;


### PR DESCRIPTION
We have allowed non-string values for `params` option (although not in TypeScript), which can lead to problems as demonstrated in issue #245

Now printing a warning message when used with non-string values.

With a plan of replacing this warning with a hard error in next major version.