### PR TITLE
Update VSCode extension for sql-formatter v8

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -213,16 +213,6 @@
           "default": "after",
           "markdownDescription": "Where to place commas for SELECT and GROUP BY clauses"
         },
-        "Prettier-SQL.parenOptions.newlineBeforeOpenParen": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Place (, Open Paren, CASE on newline when creating a new block"
-        },
-        "Prettier-SQL.parenOptions.newlineBeforeCloseParen": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Place ), Close Paren, END on newline when closing a block"
-        },
         "Prettier-SQL.expressionWidth": {
           "type": "integer",
           "default": 50,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "prettier-sql-vscode",
   "displayName": "Prettier SQL VSCode",
   "description": "VSCode Extension to format SQL files",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "inferrinizzard",
   "author": {
     "name": "inferrinizzard"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -65,7 +65,7 @@
     "vsce": "vsce"
   },
   "dependencies": {
-    "sql-formatter": "^6.1.2"
+    "sql-formatter": "^8.0.1"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -36,8 +36,6 @@ const getConfigs = (
     aliasAs: settings.get<AliasMode>('aliasAS'),
     tabulateAlias: settings.get<boolean>('tabulateAlias'),
     commaPosition: settings.get<CommaPosition>('commaPosition'),
-    newlineBeforeOpenParen: settings.get<boolean>('newlineBeforeOpenParen'),
-    newlineBeforeCloseParen: settings.get<boolean>('newlineBeforeCloseParen'),
     expressionWidth: settings.get<number>('expressionWidth'),
     linesBetweenQueries: settings.get<number>('linesBetweenQueries'),
     denseOperators: settings.get<boolean>('denseOperators'),

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -8,6 +8,7 @@
     "rootDir": "src",
     "declaration": true,
     "strict": true /* enable all strict type-checking options */,
+    "skipLibCheck": true,
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -1889,10 +1889,10 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-sql-formatter@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-6.1.2.tgz#78b05021c641020312a5f144ec313b38e7663258"
-  integrity sha512-09AiPmA6zDq82IBXOj5kN33VeAqaV92enkoonlhJge0fmfTESiYs3pwsntGKxa1C89xj/9MoHlNeqMmCr23BJw==
+sql-formatter@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.0.1.tgz#7885a2a8d5f837d017f86aeea8ebcb5fd7c9bfcf"
+  integrity sha512-XeagEdPomEOrONVGcHz2/d3yKLHY+8FPJCw/PeHwHkKULVYxDLQKdt62Ab/34srNihpT3QTXNZHtbXBn5P5aIQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
- updated sql-formatter dep
- removed newlineBeforeOpenParen and newlineBeforeCloseParen configs