### PR TITLE
Fix formatting of BigQuery FROM clause operators

### DIFF
--- a/src/languages/bigquery.formatter.ts
+++ b/src/languages/bigquery.formatter.ts
@@ -544,6 +544,7 @@ const reservedFunctions = {
     'TO_BASE64',
   ],
   other: ['BQ.JOBS.CANCEL', 'BQ.REFRESH_MATERIALIZED_VIEW'],
+  pivot: ['PIVOT', 'UNPIVOT'],
 };
 
 /**
@@ -635,14 +636,14 @@ const reservedKeywords = {
     'SOME',
     // 'STRUCT',
     'TABLE',
-    // 'TABLESAMPLE',
+    'TABLESAMPLE SYSTEM',
     'THEN',
     'TO',
     'TREAT',
     'TRUE',
     'UNBOUNDED',
     // 'UNION',
-    // 'UNNEST',
+    'UNNEST',
     // 'USING',
     // 'WHEN',
     // 'WHERE',
@@ -689,10 +690,6 @@ const reservedCommands = [
   // DQL, https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
   'SELECT',
   'FROM',
-  'UNNEST',
-  'PIVOT',
-  'UNPIVOT',
-  'TABLESAMPLE SYSTEM',
   'WHERE',
   'GROUP BY',
   'HAVING',

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -220,4 +220,53 @@ describe('BigQueryFormatter', () => {
       `);
     });
   });
+
+  // Issue #279
+  describe('supports FROM clause operators:', () => {
+    it('UNNEST operator', () => {
+      expect(format('SELECT * FROM UNNEST ([1, 2, 3]);')).toBe(dedent`
+        SELECT
+          *
+        FROM
+          UNNEST ([1, 2, 3]);
+      `);
+    });
+
+    it('PIVOT operator', () => {
+      expect(format(`SELECT * FROM Produce PIVOT(sales FOR quarter IN (Q1, Q2, Q3, Q4));`))
+        .toBe(dedent`
+        SELECT
+          *
+        FROM
+          Produce PIVOT(
+            sales
+            FOR
+              quarter IN (Q1, Q2, Q3, Q4)
+          );
+      `);
+    });
+
+    it('UNPIVOT operator', () => {
+      expect(format(`SELECT * FROM Produce UNPIVOT(sales FOR quarter IN (Q1, Q2, Q3, Q4));`))
+        .toBe(dedent`
+        SELECT
+          *
+        FROM
+          Produce UNPIVOT(
+            sales
+            FOR
+              quarter IN (Q1, Q2, Q3, Q4)
+          );
+      `);
+    });
+
+    it('TABLESAMPLE SYSTEM operator', () => {
+      expect(format(`SELECT * FROM dataset.my_table TABLESAMPLE SYSTEM (10 PERCENT);`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          dataset.my_table TABLESAMPLE SYSTEM (10 PERCENT);
+      `);
+    });
+  });
 });


### PR DESCRIPTION
These operators were previously misclassified as RESERVED_COMMANDs:

- [UNNEST](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unnest_operator)
- [PIVOT](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#pivot_operator)
- [UNPIVOT](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unpivot_operator)
- [TABLESAMPLE SYSTEM](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#tablesample_operator)

Refs #279 