### PR TITLE
Fix BigQuery STRUCT formatting

### DIFF
--- a/src/languages/bigquery.formatter.ts
+++ b/src/languages/bigquery.formatter.ts
@@ -895,9 +895,9 @@ function combineParameterizedTypes(tokens: Token[]) {
       const endIndex = findClosingAngleBracketIndex(tokens, i + 1);
       const typeDefTokens = tokens.slice(i, endIndex + 1);
       processed.push({
-        ...token,
-        value: typeDefTokens.map(formatTypeDefToken).join(''),
-        text: typeDefTokens.map(formatTypeDefToken).join(''),
+        type: TokenType.IDENT,
+        value: typeDefTokens.map(formatTypeDefToken('value')).join(''),
+        text: typeDefTokens.map(formatTypeDefToken('text')).join(''),
       });
       i = endIndex;
     } else {
@@ -907,13 +907,15 @@ function combineParameterizedTypes(tokens: Token[]) {
   return processed;
 }
 
-function formatTypeDefToken({ type, value, text }: Token): string {
-  if (type === TokenType.IDENT || value === ',') {
-    return text + ' ';
-  } else {
-    return text;
-  }
-}
+const formatTypeDefToken =
+  (key: 'text' | 'value') =>
+  (token: Token): string => {
+    if (token.type === TokenType.IDENT || token.value === ',') {
+      return token[key] + ' ';
+    } else {
+      return token[key];
+    }
+  };
 
 function findClosingAngleBracketIndex(tokens: Token[], startIndex: number): number {
   let level = 0;

--- a/src/languages/bigquery.formatter.ts
+++ b/src/languages/bigquery.formatter.ts
@@ -896,8 +896,8 @@ function combineParameterizedTypes(tokens: Token[]) {
       const typeDefTokens = tokens.slice(i, endIndex + 1);
       processed.push({
         ...token,
-        value: typeDefTokens.map(t => t.value).join(''),
-        text: typeDefTokens.map(t => t.text).join(''),
+        value: typeDefTokens.map(formatTypeDefToken).join(''),
+        text: typeDefTokens.map(formatTypeDefToken).join(''),
       });
       i = endIndex;
     } else {
@@ -905,6 +905,14 @@ function combineParameterizedTypes(tokens: Token[]) {
     }
   }
   return processed;
+}
+
+function formatTypeDefToken({ type, value, text }: Token): string {
+  if (type === TokenType.IDENT || value === ',') {
+    return text + ' ';
+  } else {
+    return text;
+  }
 }
 
 function findClosingAngleBracketIndex(tokens: Token[], startIndex: number): number {

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -131,6 +131,25 @@ describe('BigQueryFormatter', () => {
     `);
   });
 
+  it('supports uppercasing of STRUCT', () => {
+    expect(format('select struct<Nr int64, myName string>(1,"foo");', { keywordCase: 'upper' }))
+      .toBe(dedent`
+      SELECT
+        STRUCT<Nr INT64, myName STRING>(1, "foo");
+    `);
+  });
+
+  // XXX: This is hard to achieve with our current type-parameter processing hack.
+  // At least we're preserving the case of identifier names here,
+  // and lowercasing is luckily less used than uppercasing.
+  it('does not support lowercasing of STRUCT', () => {
+    expect(format('SELECT STRUCT<Nr INT64, myName STRING>(1,"foo");', { keywordCase: 'lower' }))
+      .toBe(dedent`
+      select
+        STRUCT<Nr INT64, myName STRING>(1, "foo");
+    `);
+  });
+
   it('supports parameterised types', () => {
     const result = format(
       `

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -121,6 +121,16 @@ describe('BigQueryFormatter', () => {
     `);
   });
 
+  // Issue #279
+  it('supports parametric STRUCT with named fields', () => {
+    expect(format('SELECT STRUCT<y INT64, z STRING>(1,"foo"), STRUCT<arr ARRAY<INT64>>([1,2,3]);'))
+      .toBe(dedent`
+      SELECT
+        STRUCT<y INT64, z STRING>(1, "foo"),
+        STRUCT<arr ARRAY<INT64>>([1, 2, 3]);
+    `);
+  });
+
   it('supports parameterised types', () => {
     const result = format(
       `


### PR DESCRIPTION
Properly add spaces when concatenating type parameter tokens.

Fixes #279