### PR TITLE
VSCode/v1.1.1

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,5 +1,34 @@
 # CHANGELOG
 
+## [1.1.0] - 2022-07-05
+
+- updated `sql-formatter` to v8.x
+- removed `newlineBeforeCloseParen`
+- removed `newlineBeforeOpenParen`
+
+## [1.0.0] - 2022-06-02
+
+- switched from `prettier-sql` to `sql-formatter` as base library
+- renamed `uppercaseKeywords` to `keywordCase`, changed from boolean to enum
+- renamed `keywordPosition` to `indentStyle`
+- renamed `breakBeforeBooleanOperator` to `logicalOperatorNewline`
+- renamed `closeParenNewline` to `newlineBeforeCloseParen`
+- renamed `openParenNewline` to `newlineBeforeOpenParen`
+- renamed `lineWidth` to `expressionWidth`
+- renamed `semicolonNewline` to `newlineBeforeSemicolon`
+- added `'preserve'` option for `aliasAS`
+- removed `keywordNewline`
+- removed `itemCount`
+- added formatProvider support on new languages:
+  - sqlite
+
+## [0.3.0] - 2022-04-09
+
+- updated dependencies
+- update build and publish flow
+- renamed `keywordNewline` to `keywordNewline.newlineMode`, remove integer option
+- restored deleted `itemCount` as `keywordNewline.itemCount`
+
 ## [0.2.0] - 2021-12-21
 
 - added command `prettier-sql-vscode.format-selection`

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.1.1] - 2022-07-05
+
+- updated package metadata to point at `sql-formatter` instead of `prettier-sql`
+
 ## [1.1.0] - 2022-07-05
 
 - updated `sql-formatter` to v8.x

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -18,11 +18,11 @@ Use the FORMATTING template if it is an issue related the formatting of the SQL,
 
 `Prettier-SQL.insertSpacesOverride`: Overrides `insertSpaces` if `Prettier-SQL.ignoreTabSettings` is enabled
 
-`Prettier-SQL.uppercaseKeywords`: Whether to print keywords in ALL CAPS or lowercase
+`Prettier-SQL.keywordCase`: Whether to print keywords in ALL CAPS or lowercase
 
-`Prettier-SQL.keywordPosition`: Switched between standard keyword positioning vs maintaining a central space column
+`Prettier-SQL.indentStyle`: Switched between standard keyword positioning vs maintaining a central space column
 
-`Prettier-SQL.breakBeforeBooleanOperator`: Whether to break before or after AND and OR
+`Prettier-SQL.logicalOperatorNewline`: Whether to break before or after AND and OR
 
 `Prettier-SQL.aliasAS`: Where to use AS in column or table aliases
 
@@ -30,7 +30,7 @@ Use the FORMATTING template if it is an issue related the formatting of the SQL,
 
 `Prettier-SQL.commaPosition`: Where to place commas for SELECT and GROUP BY clauses
 
-`Prettier-SQL.lineWidth`: Number of characters allowed in each line before breaking
+`Prettier-SQL.expressionWidth`: Number of characters allowed in each line before breaking
 
 `Prettier-SQL.linesBetweenQueries`: How many newlines to place between each query / statement
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,10 +1,10 @@
 # Prettier SQL
 
-Formats SQL files using the [`prettier-sql`](https://github.com/inferrinizzard/prettier-sql) library
+Formats SQL files using the [`sql-formatter`](https://github.com/sql-formatter-org/sql-formatter) library
 
 ## Issues
 
-Please report issues here: https://github.com/inferrinizzard/prettier-sql/issues
+Please report issues here: https://github.com/sql-formatter-org/sql-formatter/issues
 
 Use the FORMATTING template if it is an issue related the formatting of the SQL, otherwise, please use the VSCODE template for issues with running the VSCode Extension
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -30,12 +30,6 @@ Use the FORMATTING template if it is an issue related the formatting of the SQL,
 
 `Prettier-SQL.commaPosition`: Where to place commas for SELECT and GROUP BY clauses
 
-`Prettier-SQL.keywordNewline`: Rule for when to break keyword clauses onto a newline
-
-`Prettier-SQL.openParenNewline`: Whether to place (, Open Paren, CASE on newline when creating a new block
-
-`Prettier-SQL.closeParenNewline`: Whether to place ), Close Paren, END on newline when closing a block
-
 `Prettier-SQL.lineWidth`: Number of characters allowed in each line before breaking
 
 `Prettier-SQL.linesBetweenQueries`: How many newlines to place between each query / statement

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -42,6 +42,7 @@
     "spark",
     "sparksql",
     "sql",
+    "sqlite",
     "sql server",
     "tsql"
   ],

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -14,10 +14,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/inferrinizzard/prettier-sql"
+    "url": "https://github.com/sql-formatter-org/sql-formatter"
   },
   "bugs": {
-    "url": "https://github.com/inferrinizzard/prettier-sql/issues"
+    "url": "https://github.com/sql-formatter-org/sql-formatter/issues"
   },
   "categories": [
     "Formatters",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "prettier-sql-vscode",
   "displayName": "Prettier SQL VSCode",
   "description": "VSCode Extension to format SQL files",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publisher": "inferrinizzard",
   "author": {
     "name": "inferrinizzard"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -65,7 +65,7 @@
     "vsce": "vsce"
   },
   "dependencies": {
-    "sql-formatter": "^8.0.1"
+    "sql-formatter": "^8.0.2"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -1889,10 +1889,10 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-sql-formatter@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.0.1.tgz#7885a2a8d5f837d017f86aeea8ebcb5fd7c9bfcf"
-  integrity sha512-XeagEdPomEOrONVGcHz2/d3yKLHY+8FPJCw/PeHwHkKULVYxDLQKdt62Ab/34srNihpT3QTXNZHtbXBn5P5aIQ==
+sql-formatter@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.0.2.tgz#33ff53de3cf8b8a520ef54d7fb66d32cd29bc93d"
+  integrity sha512-cmDmL0Ji92vAvX+J7BI5paHBDsJZV6uKIDeUiykChMXw6P8W9OB+iCsLzDjtVlOca3fHlFoMs25U7u2OFOQOKQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
- updated package metadata to point at this repo instead of old repo
- renamed settings in README
- update forgotten CHANGELOG for missed releases