### PR TITLE
Drop the no-unused-expressions rule override

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,6 @@
     "no-useless-concat": "off",
     "no-restricted-syntax": "off",
     "no-constant-condition": "off",
-    "no-unused-expressions": "warn",
     "prefer-template": "off",
     "default-case": "off",
     "prettier/prettier": ["error"],


### PR DESCRIPTION
This rule is defined in airbnb-base from which we inherit.

No need to change it from error to warning.