### PR TITLE
Remove !assertions and other small refactors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,8 @@
       "single",
       { "avoidEscape": true, "allowTemplateLiterals": true }
     ],
-    "@typescript-eslint/semi": "error"
+    "@typescript-eslint/semi": "error",
+    "@typescript-eslint/no-non-null-assertion": "error"
   },
   "settings": {
     "import/resolver": {

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -57,7 +57,7 @@ interface TokenizerOptions {
 }
 
 export default class Tokenizer {
-  engine: TokenizerEngine;
+  private engine: TokenizerEngine;
   private postProcess?: (tokens: Token[]) => Token[];
 
   constructor(cfg: TokenizerOptions) {
@@ -158,7 +158,7 @@ export default class Tokenizer {
     this.postProcess = cfg.postProcess;
   }
 
-  tokenize(input: string): Token[] {
+  public tokenize(input: string): Token[] {
     const tokens = this.engine.tokenize(input);
     return this.postProcess ? this.postProcess(tokens) : tokens;
   }

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -57,12 +57,11 @@ interface TokenizerOptions {
 }
 
 export default class Tokenizer {
-  private TOKENIZER_RULES: Partial<Record<TokenType, TokenRule | { regex: undefined }>>;
   engine: TokenizerEngine;
   private postProcess?: (tokens: Token[]) => Token[];
 
   constructor(cfg: TokenizerOptions) {
-    this.TOKENIZER_RULES = {
+    const rules: Partial<Record<TokenType, TokenRule | { regex: undefined }>> = {
       [TokenType.BLOCK_COMMENT]: { regex: /(\/\*[^]*?(?:\*\/|$))/uy },
       [TokenType.LINE_COMMENT]: {
         regex: regex.lineComment(cfg.lineCommentTypes ?? ['--']),
@@ -152,7 +151,7 @@ export default class Tokenizer {
 
     // filter out unsupported parameter types whose regex resolve to undefined
     const withoutUnsupportedParameters = Object.fromEntries(
-      Object.entries(this.TOKENIZER_RULES).filter(([_, rule]) => rule.regex)
+      Object.entries(rules).filter(([_, rule]) => rule.regex)
     );
     this.engine = new TokenizerEngine(withoutUnsupportedParameters);
 

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -8,15 +8,15 @@ export interface TokenRule {
 }
 
 export default class TokenizerEngine {
-  private REGEX_MAP: Partial<Record<TokenType, TokenRule>>;
+  private rules: Partial<Record<TokenType, TokenRule>>;
 
   // The input SQL string to process
   private input = '';
   // Current position in string
   private index = 0;
 
-  constructor(tokenizerRules: Partial<Record<TokenType, TokenRule>>) {
-    this.REGEX_MAP = tokenizerRules;
+  constructor(rules: Partial<Record<TokenType, TokenRule>>) {
+    this.rules = rules;
   }
 
   /**
@@ -85,9 +85,9 @@ export default class TokenizerEngine {
   }
 
   private matchPlaceholderToken(tokenType: TokenType): Token | undefined {
-    if (tokenType in this.REGEX_MAP) {
+    if (tokenType in this.rules) {
       const token = this.matchToken(tokenType);
-      const tokenRule = this.REGEX_MAP[tokenType];
+      const tokenRule = this.rules[tokenType];
       if (token) {
         if (tokenRule?.key) {
           return { ...token, key: tokenRule.key(token.value) };
@@ -119,9 +119,9 @@ export default class TokenizerEngine {
     );
   }
 
-  // Shorthand for `match` that looks up regex from REGEX_MAP
+  // Shorthand for `match` that looks up regex from rules
   private matchToken(tokenType: TokenType): Token | undefined {
-    const rule = this.REGEX_MAP[tokenType];
+    const rule = this.rules[tokenType];
     if (!rule) {
       throw Error(`Unknown token type found: ${tokenType}`);
     }

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -121,13 +121,14 @@ export default class TokenizerEngine {
 
   // Shorthand for `match` that looks up regex from REGEX_MAP
   private matchToken(tokenType: TokenType): Token | undefined {
-    if (!(tokenType in this.REGEX_MAP)) {
+    const rule = this.REGEX_MAP[tokenType];
+    if (!rule) {
       throw Error(`Unknown token type found: ${tokenType}`);
     }
     return this.match({
       type: tokenType,
-      regex: this.REGEX_MAP[tokenType]!.regex,
-      transform: this.REGEX_MAP[tokenType]!.value,
+      regex: rule.regex,
+      transform: rule.value,
     });
   }
 


### PR DESCRIPTION
Eliminated use of typescript non-null assertions and added ESLint rule to avoid them in to future. Or at least to make it easier to spot these cases, as the `!` character is such a small thing to notice when reviewing code.

Plus a few additional little changes.