### PR TITLE
Fix parsing and formatting of LIMIT clause

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -160,18 +160,14 @@ export default class ExpressionFormatter {
     this.layout.add(WS.NEWLINE, WS.INDENT, this.show(node.limitToken));
     this.layout.indentation.increaseTopLevel();
 
-    if (node.offsetToken) {
-      this.layout.add(
-        WS.NEWLINE,
-        WS.INDENT,
-        this.show(node.offsetToken),
-        ',',
-        WS.SPACE,
-        this.show(node.countToken),
-        WS.SPACE
-      );
+    if (node.offset) {
+      this.layout.add(WS.NEWLINE, WS.INDENT);
+      this.layout = this.formatSubExpression(node.offset);
+      this.layout.add(WS.NO_SPACE, ',', WS.SPACE);
+      this.layout = this.formatSubExpression(node.count);
     } else {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.show(node.countToken), WS.SPACE);
+      this.layout.add(WS.NEWLINE, WS.INDENT);
+      this.layout = this.formatSubExpression(node.count);
     }
     this.layout.indentation.decreaseTopLevel();
   }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -162,20 +162,25 @@ export default class Parser {
   }
 
   private limitClause(): LimitClause | undefined {
-    if (isToken.LIMIT(this.look()) && this.look(2).type === TokenType.COMMA) {
-      return {
-        type: NodeType.limit_clause,
-        limitToken: this.next(),
-        offset: [this.nextTokenNode()],
-        count: this.next() && [this.nextTokenNode()], // Discard comma token
-      };
-    }
     if (isToken.LIMIT(this.look())) {
-      return {
-        type: NodeType.limit_clause,
-        limitToken: this.next(),
-        count: [this.nextTokenNode()],
-      };
+      const limitToken = this.next();
+      const expr1 = [this.expression()];
+      if (this.look().type === TokenType.COMMA) {
+        this.next(); // Discard comma token
+        const expr2 = [this.expression()];
+        return {
+          type: NodeType.limit_clause,
+          limitToken,
+          offset: expr1,
+          count: expr2,
+        };
+      } else {
+        return {
+          type: NodeType.limit_clause,
+          limitToken,
+          count: expr1,
+        };
+      }
     }
     return undefined;
   }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -166,15 +166,15 @@ export default class Parser {
       return {
         type: NodeType.limit_clause,
         limitToken: this.next(),
-        offsetToken: this.next(),
-        countToken: this.next() && this.next(), // Discard comma token
+        offset: [this.nextTokenNode()],
+        count: this.next() && [this.nextTokenNode()], // Discard comma token
       };
     }
     if (isToken.LIMIT(this.look())) {
       return {
         type: NodeType.limit_clause,
         limitToken: this.next(),
-        countToken: this.next(),
+        count: [this.nextTokenNode()],
       };
     }
     return undefined;

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -91,7 +91,7 @@ export default class Parser {
         this.look().type !== TokenType.RESERVED_BINARY_COMMAND &&
         this.look().type !== TokenType.EOF &&
         this.look().type !== TokenType.CLOSE_PAREN &&
-        this.look().value !== TokenType.DELIMITER
+        this.look().type !== TokenType.DELIMITER
       ) {
         children.push(this.expression());
       }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -164,10 +164,10 @@ export default class Parser {
   private limitClause(): LimitClause | undefined {
     if (isToken.LIMIT(this.look())) {
       const limitToken = this.next();
-      const expr1 = [this.expression()];
+      const expr1 = this.expressionsUntilCommaOrClauseEnd();
       if (this.look().type === TokenType.COMMA) {
         this.next(); // Discard comma token
-        const expr2 = [this.expression()];
+        const expr2 = this.expressionsUntilClauseEnd();
         return {
           type: NodeType.limit_clause,
           limitToken,
@@ -183,6 +183,35 @@ export default class Parser {
       }
     }
     return undefined;
+  }
+
+  private expressionsUntilCommaOrClauseEnd(): AstNode[] {
+    const children: AstNode[] = [];
+    while (
+      this.look().type !== TokenType.RESERVED_COMMAND &&
+      this.look().type !== TokenType.RESERVED_BINARY_COMMAND &&
+      this.look().type !== TokenType.EOF &&
+      this.look().type !== TokenType.CLOSE_PAREN &&
+      this.look().type !== TokenType.DELIMITER &&
+      this.look().type !== TokenType.COMMA
+    ) {
+      children.push(this.expression());
+    }
+    return children;
+  }
+
+  private expressionsUntilClauseEnd(): AstNode[] {
+    const children: AstNode[] = [];
+    while (
+      this.look().type !== TokenType.RESERVED_COMMAND &&
+      this.look().type !== TokenType.RESERVED_BINARY_COMMAND &&
+      this.look().type !== TokenType.EOF &&
+      this.look().type !== TokenType.CLOSE_PAREN &&
+      this.look().type !== TokenType.DELIMITER
+    ) {
+      children.push(this.expression());
+    }
+    return children;
   }
 
   private allColumnsAsterisk(): AllColumnsAsterisk | undefined {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -67,16 +67,7 @@ export default class Parser {
   private clause(): Clause | undefined {
     if (this.look().type === TokenType.RESERVED_COMMAND) {
       const name = this.next();
-      const children: AstNode[] = [];
-      while (
-        this.look().type !== TokenType.RESERVED_COMMAND &&
-        this.look().type !== TokenType.RESERVED_BINARY_COMMAND &&
-        this.look().type !== TokenType.EOF &&
-        this.look().type !== TokenType.CLOSE_PAREN &&
-        this.look().type !== TokenType.DELIMITER
-      ) {
-        children.push(this.expression());
-      }
+      const children = this.expressionsUntilClauseEnd();
       return { type: NodeType.clause, nameToken: name, children };
     }
     return undefined;
@@ -85,16 +76,7 @@ export default class Parser {
   private binaryClause(): BinaryClause | undefined {
     if (this.look().type === TokenType.RESERVED_BINARY_COMMAND) {
       const name = this.next();
-      const children: AstNode[] = [];
-      while (
-        this.look().type !== TokenType.RESERVED_COMMAND &&
-        this.look().type !== TokenType.RESERVED_BINARY_COMMAND &&
-        this.look().type !== TokenType.EOF &&
-        this.look().type !== TokenType.CLOSE_PAREN &&
-        this.look().type !== TokenType.DELIMITER
-      ) {
-        children.push(this.expression());
-      }
+      const children = this.expressionsUntilClauseEnd();
       return { type: NodeType.binary_clause, nameToken: name, children };
     }
     return undefined;

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -71,8 +71,8 @@ export type BetweenPredicate = {
 export type LimitClause = {
   type: NodeType.limit_clause;
   limitToken: Token;
-  countToken: Token;
-  offsetToken?: Token;
+  count: AstNode[];
+  offset?: AstNode[];
 };
 
 // The "*" operator used in SELECT *

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -15,6 +15,7 @@ import supportsLinesBetweenQueries from './options/linesBetweenQueries';
 import supportsNewlineBeforeSemicolon from './options/newlineBeforeSemicolon';
 import supportsLogicalOperatorNewline from './options/logicalOperatorNewline';
 import supportsTabulateAlias from './options/tabulateAlias';
+import supportsLimit from './features/limit';
 
 /**
  * Core tests for all SQL formatters
@@ -34,6 +35,7 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
   supportsNewlineBeforeSemicolon(format);
   supportsCommaPosition(format);
   supportsLogicalOperatorNewline(format);
+  supportsLimit(format);
 
   it('formats simple SELECT query', () => {
     const result = format('SELECT count(*),Column1 FROM Table1;');
@@ -132,56 +134,6 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
       ORDER BY
         col1 ASC,
         col2 DESC;
-    `);
-  });
-
-  it('formats LIMIT with two comma-separated values on single line', () => {
-    const result = format('LIMIT 5, 10;');
-    expect(result).toBe(dedent`
-      LIMIT
-        5, 10;
-    `);
-  });
-
-  it('formats LIMIT of single value followed by another SELECT using commas', () => {
-    const result = format('LIMIT 5; SELECT foo, bar;');
-    expect(result).toBe(dedent`
-      LIMIT
-        5;
-
-      SELECT
-        foo,
-        bar;
-    `);
-  });
-
-  it('formats LIMIT of single value and OFFSET', () => {
-    const result = format('LIMIT 5 OFFSET 8;');
-    expect(result).toBe(dedent`
-      LIMIT
-        5
-      OFFSET
-        8;
-    `);
-  });
-
-  // Regression test for #303
-  it('formats LIMIT with complex expressions', () => {
-    const result = format('LIMIT abs(-5) - 1, (2 + 3) * 5;');
-    expect(result).toBe(dedent`
-      LIMIT
-        abs(-5) - 1, (2 + 3) * 5;
-    `);
-  });
-
-  // Regression test for #301
-  it('formats LIMIT with comments', () => {
-    const result = format('LIMIT --comment\n 5,--comment\n6;');
-    expect(result).toBe(dedent`
-      LIMIT
-        --comment
-        5, --comment
-        6;
     `);
   });
 

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -165,6 +165,14 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
     `);
   });
 
+  it('formats LIMIT with function calls', () => {
+    const result = format('LIMIT abs(-5), sqrt(2);');
+    expect(result).toBe(dedent`
+      LIMIT
+        abs(-5), sqrt(2);
+    `);
+  });
+
   it('formats SELECT query with SELECT query inside it', () => {
     const result = format(
       'SELECT *, SUM(*) AS total FROM (SELECT * FROM Posts LIMIT 30) WHERE a > b'

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -165,11 +165,11 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
     `);
   });
 
-  it('formats LIMIT with function calls', () => {
-    const result = format('LIMIT abs(-5), sqrt(2);');
+  it('formats LIMIT with complex expressions', () => {
+    const result = format('LIMIT abs(-5) - 1, (2 + 3) * 5;');
     expect(result).toBe(dedent`
       LIMIT
-        abs(-5), sqrt(2);
+        abs(-5) - 1, (2 + 3) * 5;
     `);
   });
 

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -165,11 +165,23 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
     `);
   });
 
+  // Regression test for #303
   it('formats LIMIT with complex expressions', () => {
     const result = format('LIMIT abs(-5) - 1, (2 + 3) * 5;');
     expect(result).toBe(dedent`
       LIMIT
         abs(-5) - 1, (2 + 3) * 5;
+    `);
+  });
+
+  // Regression test for #301
+  it('formats LIMIT with comments', () => {
+    const result = format('LIMIT --comment\n 5,--comment\n6;');
+    expect(result).toBe(dedent`
+      LIMIT
+        --comment
+        5, --comment
+        6;
     `);
   });
 

--- a/test/features/limit.ts
+++ b/test/features/limit.ts
@@ -1,0 +1,55 @@
+import dedent from 'dedent-js';
+
+import { FormatFn } from 'src/sqlFormatter';
+
+export default function supportsLimit(format: FormatFn) {
+  it('formats LIMIT with two comma-separated values on single line', () => {
+    const result = format('LIMIT 5, 10;');
+    expect(result).toBe(dedent`
+      LIMIT
+        5, 10;
+    `);
+  });
+
+  it('formats LIMIT of single value followed by another SELECT using commas', () => {
+    const result = format('LIMIT 5; SELECT foo, bar;');
+    expect(result).toBe(dedent`
+      LIMIT
+        5;
+
+      SELECT
+        foo,
+        bar;
+    `);
+  });
+
+  it('formats LIMIT of single value and OFFSET', () => {
+    const result = format('LIMIT 5 OFFSET 8;');
+    expect(result).toBe(dedent`
+      LIMIT
+        5
+      OFFSET
+        8;
+    `);
+  });
+
+  // Regression test for #303
+  it('formats LIMIT with complex expressions', () => {
+    const result = format('LIMIT abs(-5) - 1, (2 + 3) * 5;');
+    expect(result).toBe(dedent`
+      LIMIT
+        abs(-5) - 1, (2 + 3) * 5;
+    `);
+  });
+
+  // Regression test for #301
+  it('formats LIMIT with comments', () => {
+    const result = format('LIMIT --comment\n 5,--comment\n6;');
+    expect(result).toBe(dedent`
+      LIMIT
+        --comment
+        5, --comment
+        6;
+    `);
+  });
+}

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -322,12 +322,17 @@ describe('Parser', () => {
         Object {
           "children": Array [
             Object {
-              "countToken": Object {
-                "text": "10",
-                "type": "NUMBER",
-                "value": "10",
-                "whitespaceBefore": " ",
-              },
+              "count": Array [
+                Object {
+                  "token": Object {
+                    "text": "10",
+                    "type": "NUMBER",
+                    "value": "10",
+                    "whitespaceBefore": " ",
+                  },
+                  "type": "token",
+                },
+              ],
               "limitToken": Object {
                 "text": "LIMIT",
                 "type": "RESERVED_COMMAND",
@@ -350,24 +355,34 @@ describe('Parser', () => {
         Object {
           "children": Array [
             Object {
-              "countToken": Object {
-                "text": "10",
-                "type": "NUMBER",
-                "value": "10",
-                "whitespaceBefore": " ",
-              },
+              "count": Array [
+                Object {
+                  "token": Object {
+                    "text": "10",
+                    "type": "NUMBER",
+                    "value": "10",
+                    "whitespaceBefore": " ",
+                  },
+                  "type": "token",
+                },
+              ],
               "limitToken": Object {
                 "text": "LIMIT",
                 "type": "RESERVED_COMMAND",
                 "value": "LIMIT",
                 "whitespaceBefore": "",
               },
-              "offsetToken": Object {
-                "text": "200",
-                "type": "NUMBER",
-                "value": "200",
-                "whitespaceBefore": " ",
-              },
+              "offset": Array [
+                Object {
+                  "token": Object {
+                    "text": "200",
+                    "type": "NUMBER",
+                    "value": "200",
+                    "whitespaceBefore": " ",
+                  },
+                  "type": "token",
+                },
+              ],
               "type": "limit_clause",
             },
           ],


### PR DESCRIPTION
This serves as a case study of how easy it is to get things wrong when parsing even very simple SQL expressions.

Fixes #301
Fixes #303
