### PR TITLE
Fix parameters replacement in BETWEEN expressions

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -219,16 +219,14 @@ export default class ExpressionFormatter {
       case TokenType.QUOTED_PARAMETER:
       case TokenType.INDEXED_PARAMETER:
       case TokenType.POSITIONAL_PARAMETER:
-        return this.formatWord(token);
+        return this.formatLiteral(token);
       default:
         throw new Error(`Unexpected token type: ${token.type}`);
     }
   }
 
-  /**
-   * Formats ident/string/number/variable tokens
-   */
-  private formatWord(token: Token) {
+  /** Default formatting for most token types */
+  private formatLiteral(token: Token) {
     this.layout.add(this.show(token), WS.SPACE);
   }
 

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -3,7 +3,7 @@ import { equalizeWhitespace } from 'src/utils';
 
 import Params from 'src/formatter/Params';
 import { isTabularStyle } from 'src/formatter/config';
-import { isReserved, type Token, TokenType } from 'src/lexer/token';
+import { isReserved, type Token, TokenType, isParameter } from 'src/lexer/token';
 import {
   AllColumnsAsterisk,
   ArraySubscript,
@@ -392,6 +392,8 @@ export default class ExpressionFormatter {
         case 'lower':
           return token.value.toLowerCase();
       }
+    } else if (isParameter(token)) {
+      return this.params.get(token);
     } else {
       return token.value;
     }

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -206,11 +206,6 @@ export default class ExpressionFormatter {
         return this.formatCaseStart(token);
       case TokenType.RESERVED_CASE_END:
         return this.formatCaseEnd(token);
-      case TokenType.NAMED_PARAMETER:
-      case TokenType.QUOTED_PARAMETER:
-      case TokenType.INDEXED_PARAMETER:
-      case TokenType.POSITIONAL_PARAMETER:
-        return this.formatParameter(token);
       case TokenType.COMMA:
         return this.formatComma(token);
       case TokenType.OPERATOR:
@@ -220,6 +215,10 @@ export default class ExpressionFormatter {
       case TokenType.STRING:
       case TokenType.NUMBER:
       case TokenType.VARIABLE:
+      case TokenType.NAMED_PARAMETER:
+      case TokenType.QUOTED_PARAMETER:
+      case TokenType.INDEXED_PARAMETER:
+      case TokenType.POSITIONAL_PARAMETER:
         return this.formatWord(token);
       default:
         throw new Error(`Unexpected token type: ${token.type}`);
@@ -353,13 +352,6 @@ export default class ExpressionFormatter {
     this.layout.indentation.decreaseBlockLevel();
 
     this.layout.add(WS.NEWLINE, WS.INDENT, this.show(token), WS.SPACE);
-  }
-
-  /**
-   * Formats a parameter placeholder item onto query, to be replaced with the value of the placeholder
-   */
-  private formatParameter(token: Token) {
-    this.layout.add(this.params.get(token), WS.SPACE);
   }
 
   /**

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -85,3 +85,10 @@ export const isReserved = (token: Token): boolean =>
   token.type === TokenType.RESERVED_JOIN ||
   token.type === TokenType.RESERVED_CASE_START ||
   token.type === TokenType.RESERVED_CASE_END;
+
+/** checks if token is one of the parameter tokens */
+export const isParameter = (token: Token): boolean =>
+  token.type === TokenType.INDEXED_PARAMETER ||
+  token.type === TokenType.NAMED_PARAMETER ||
+  token.type === TokenType.POSITIONAL_PARAMETER ||
+  token.type === TokenType.QUOTED_PARAMETER;

--- a/test/options/param.ts
+++ b/test/options/param.ts
@@ -33,6 +33,19 @@ export default function supportsParams(format: FormatFn, params: ParamsTypes) {
             third;
         `);
       });
+
+      // Regression test for issue #316
+      it('replaces ? positional placeholders inside BETWEEN expression', () => {
+        const result = format('SELECT name WHERE age BETWEEN ? AND ?;', {
+          params: ['5', '10'],
+        });
+        expect(result).toBe(dedent`
+          SELECT
+            name
+          WHERE
+            age BETWEEN 5 AND 10;
+        `);
+      });
     }
 
     if (params.numbered?.includes('?')) {


### PR DESCRIPTION
A generic fix that should eliminate the same problem from happening in other places as well.

Fixes #316 