### PR TITLE
Set VSCode aliasAs default to preserve

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -191,7 +191,7 @@
             "Use AS only in SELECT clauses",
             "Do not use AS for aliases"
           ],
-          "default": "select",
+          "default": "preserve",
           "markdownDescription": "Where to use AS in column or table aliases"
         },
         "Prettier-SQL.tabulateAlias": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -66,7 +66,7 @@
     "vsce": "vsce"
   },
   "dependencies": {
-    "sql-formatter": "^8.0.2"
+    "sql-formatter": "^8.2.0"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -63,7 +63,8 @@
     "lint": "eslint src --ext ts",
     "pretest": "yarn run compile && yarn run lint",
     "test": "node ./out/test/runTest.js",
-    "vsce": "vsce"
+    "vsce:package": "vsce package",
+    "vsce:publish": "vsce publish"
   },
   "dependencies": {
     "sql-formatter": "^8.2.0"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "prettier-sql-vscode",
   "displayName": "Prettier SQL VSCode",
   "description": "VSCode Extension to format SQL files",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "publisher": "inferrinizzard",
   "author": {
     "name": "inferrinizzard"

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -1889,10 +1889,10 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-sql-formatter@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.0.2.tgz#33ff53de3cf8b8a520ef54d7fb66d32cd29bc93d"
-  integrity sha512-cmDmL0Ji92vAvX+J7BI5paHBDsJZV6uKIDeUiykChMXw6P8W9OB+iCsLzDjtVlOca3fHlFoMs25U7u2OFOQOKQ==
+sql-formatter@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.2.0.tgz#2b664f02bb6b7bb6fcad1346e850b8f583303469"
+  integrity sha512-5hQOSOk8jfhPkNgUmpm+9Fn2aaLWcf4vKL/dIvUN5q9rsamKHSyN/gL79xpkETNOyL+Zv5BMQfA7z9Rmz/DJJg==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
- upgrade sql-formatter version
- set aliasAs default to `'preserve'`

Resolves #321 