### PR TITLE
Document Trino syntax for SELECT clauses

### DIFF
--- a/sql/group-by.md
+++ b/sql/group-by.md
@@ -83,6 +83,20 @@ There's a considerable variation is dialects:
       | ROLLUP "(" group_expr ["," ...] ")"
       | CUBE "(" group_expr ["," ...] ")"
 
+[Trino][]:
+
+    GROUP BY [ALL | DISTINCT] {grp_set | rollup_cube | grouping_sets} ["," ...]
+
+    rollup_cube:
+      [ROLLUP | CUBE] "(" expr ["," ...] ")"
+
+    grouping_sets:
+      GROUPING SETS "(" grp_set ["," ...] ")"
+
+    grp_set:
+        expr
+      | "(" expr ["," ...] ")"
+
 [sql standard]: https://jakewheat.github.io/sql-overview/sql-2008-foundation-grammar.html#query-specification
 [bigquery]: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#group_by_clause
 [db2]: https://www.ibm.com/docs/en/db2/9.7?topic=queries-subselect#r0000875__grpby
@@ -96,3 +110,4 @@ There's a considerable variation is dialects:
 [spark]: https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select.html
 [sqlite]: https://www.sqlite.org/lang_select.html
 [transact-sql]: https://docs.microsoft.com/en-US/sql/t-sql/queries/select-group-by-transact-sql?view=sql-server-ver15
+[trino]: https://github.com/trinodb/trino/blob/c7b26825218d5d11e9469984977dee6856f362ff/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L257

--- a/sql/limit.md
+++ b/sql/limit.md
@@ -75,6 +75,14 @@ Starting with [SQL Server 2012][], one can use the `OFFSET FETCH` syntax:
     OFFSET offset {ROW | ROWS}
     [FETCH {FIRST | NEXT} count {ROW | ROWS} ONLY]
 
+[Trino][]:
+
+    [OFFSET offset [ROW | ROWS]]
+    LIMIT count
+
+    [OFFSET offset [ROW | ROWS]]
+    FETCH {FIRST | NEXT} count {ROW | ROWS} {ONLY | WITH TIES}
+
 [sql standard]: https://jakewheat.github.io/sql-overview/sql-2008-foundation-grammar.html#query-specification
 [bigquery]: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#limit_and_offset_clause
 [db2]: https://www.ibm.com/docs/en/db2/9.7?topic=queries-subselect#r0000875__fet1st
@@ -89,3 +97,4 @@ Starting with [SQL Server 2012][], one can use the `OFFSET FETCH` syntax:
 [sqlite]: https://www.sqlite.org/lang_select.html
 [transact-sql]: https://stackoverflow.com/questions/603724/how-to-implement-limit-with-sql-server
 [sql server 2012]: https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2012/ms188385(v=sql.110)?redirectedfrom=MSDN
+[trino]: https://github.com/trinodb/trino/blob/c7b26825218d5d11e9469984977dee6856f362ff/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L212

--- a/sql/order-by.md
+++ b/sql/order-by.md
@@ -57,6 +57,10 @@ Other dialects have some variations:
 
     ORDER BY {expr [COLLATE collation] [ASC | DESC]} ["," ...]
 
+[Trino][]:
+
+    ORDER BY {expr [ASC | DESC] [NULLS FIRST | NULLS LAST]} ["," ...]
+
 [sql standard]: https://jakewheat.github.io/sql-overview/sql-2008-foundation-grammar.html#order-by-clause
 [bigquery]: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#order_by_clause
 [db2]: https://www.ibm.com/docs/en/db2/9.7?topic=queries-subselect#r0000875__orderby
@@ -70,3 +74,4 @@ Other dialects have some variations:
 [spark]: https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select.html
 [sqlite]: https://www.sqlite.org/lang_select.html
 [transact-sql]: https://docs.microsoft.com/en-US/sql/t-sql/queries/select-order-by-clause-transact-sql?view=sql-server-ver15
+[trino]: https://github.com/trinodb/trino/blob/c7b26825218d5d11e9469984977dee6856f362ff/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L212

--- a/sql/with.md
+++ b/sql/with.md
@@ -131,6 +131,13 @@ No dialect fully supports the standard:
     common_table_expression:
       identifier ["(" column_name_list ")"] AS "(" query_expression ")"
 
+[Trino][]:
+
+    WITH [RECURSIVE] common_table_expression ["," ...]
+
+    common_table_expression:
+      identifier ["(" column_name_list ")"] AS "(" query_expression ")"
+
 [sql standard]: https://jakewheat.github.io/sql-overview/sql-2008-foundation-grammar.html#with-clause
 [bigquery]: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause
 [db2]: https://www.ibm.com/docs/en/db2-for-zos/12?topic=queries-select-statement
@@ -144,3 +151,4 @@ No dialect fully supports the standard:
 [spark]: https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-cte.html
 [sqlite]: https://www.sqlite.org/syntax/common-table-expression.html
 [transact-sql]: https://docs.microsoft.com/en-us/sql/t-sql/queries/with-common-table-expression-transact-sql?view=sql-server-ver16
+[trino]: https://github.com/trinodb/trino/blob/c7b26825218d5d11e9469984977dee6856f362ff/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L178


### PR DESCRIPTION
Document the missing parts of query syntax:

- WITH
- GROUP BY
- ORDER BY
- OFFSET..LIMIT & OFFSET..FETCH

SELECT and FROM were already covered.

WHERE and HAVING clauses are the same as in all dialects.