### PR TITLE
made README snippet valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ where
 
 The tool also accepts a JSON config file with the `--config` option that takes this form:
 
-```ts
+```json
 {
   "language": "spark",
   "tabWidth": 2,
   "keywordCase": "upper",
-  "linesBetweenQueries": 2,
+  "linesBetweenQueries": 2
 }
 ```
 


### PR DESCRIPTION
The JSON snippet in the README had a trailing comma and used the wrong syntax annotation.