### PR TITLE
Add support for PLSQL Q strings

### DIFF
--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -94,8 +94,7 @@ export default class PlSqlFormatter extends Formatter {
       reservedLogicalOperators: ['AND', 'OR', 'XOR'],
       reservedKeywords: keywords,
       reservedFunctionNames: functions,
-      // TODO: support custom-delimited strings: Q'{..}' q'<..>' etc
-      stringTypes: [{ quote: "''", prefixes: ['N'] }],
+      stringTypes: [{ quote: "''", prefixes: ['N'] }, "q''"],
       identTypes: [`""`],
       identChars: { rest: '$#' },
       variableTypes: [{ regex: '&{1,2}[A-Za-z][A-Za-z0-9_$#]*' }],

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -94,7 +94,10 @@ export default class PlSqlFormatter extends Formatter {
       reservedLogicalOperators: ['AND', 'OR', 'XOR'],
       reservedKeywords: keywords,
       reservedFunctionNames: functions,
-      stringTypes: [{ quote: "''", prefixes: ['N'] }, "q''"],
+      stringTypes: [
+        { quote: "''", prefixes: ['N'] },
+        { quote: "q''", prefixes: ['N'] },
+      ],
       identTypes: [`""`],
       identChars: { rest: '$#' },
       variableTypes: [{ regex: '&{1,2}[A-Za-z][A-Za-z0-9_$#]*' }],

--- a/src/lexer/regexFactory.ts
+++ b/src/lexer/regexFactory.ts
@@ -92,10 +92,9 @@ const buildQStringPatterns = () => {
     singlePattern.replace(/{left}/g, escapeRegExp(left)).replace(/{right}/g, escapeRegExp(right))
   );
 
-  // standard pattern for common delimiters, ignores keys of specialDelimiterMap
-  const standardDelimiterPattern = String.raw`(?<tag>[^\s${escapeRegExp(
-    Object.keys(specialDelimiterMap).join('')
-  )}])(?:(?!\k<tag>).|\k<tag>(?!'))+\k<tag>`;
+  const specialDelimiters = escapeRegExp(Object.keys(specialDelimiterMap).join(''));
+  // standard pattern for common delimiters, ignores special delimiters
+  const standardDelimiterPattern = String.raw`(?<tag>[^\s${specialDelimiters}])(?:(?!\k<tag>).|\k<tag>(?!'))+\k<tag>`;
 
   // constructs final pattern by joining all cases
   const qStringPattern = `[Qq]'(?:${standardDelimiterPattern}|${patternList.join('|')})'`;

--- a/src/lexer/regexFactory.ts
+++ b/src/lexer/regexFactory.ts
@@ -85,7 +85,7 @@ const buildQStringPatterns = () => {
   };
 
   // base pattern for special delimiters, left must correspond with right
-  const singlePattern = "{left}(?:[^{right}]|{right}(?!'))+{right}";
+  const singlePattern = "{left}(?:(?!{right}').)*?{right}";
 
   // replace {left} and {right} with delimiters, collect as array
   const patternList = Object.entries(specialDelimiterMap).map(([left, right]) =>
@@ -94,7 +94,7 @@ const buildQStringPatterns = () => {
 
   const specialDelimiters = escapeRegExp(Object.keys(specialDelimiterMap).join(''));
   // standard pattern for common delimiters, ignores special delimiters
-  const standardDelimiterPattern = String.raw`(?<tag>[^\s${specialDelimiters}])(?:(?!\k<tag>).|\k<tag>(?!'))+\k<tag>`;
+  const standardDelimiterPattern = String.raw`(?<tag>[^\s${specialDelimiters}])(?:(?!\k<tag>').)*?\k<tag>`;
 
   // constructs final pattern by joining all cases
   const qStringPattern = `[Qq]'(?:${standardDelimiterPattern}|${patternList.join('|')})'`;

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -91,7 +91,7 @@ describe('PlSqlFormatter', () => {
     `);
   });
 
-  it.only('supports Q custom delimiter strings', () => {
+  it('supports Q custom delimiter strings', () => {
     expect(format("q'<test string < > 'foo' bar >'")).toBe("q'<test string < > 'foo' bar >'");
     expect(format("Q'[test string [ ] 'foo' bar ]'")).toBe("Q'[test string [ ] 'foo' bar ]'");
     expect(format("q'(test string ( ) 'foo' bar )'")).toBe("q'(test string ( ) 'foo' bar )'");

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -91,6 +91,15 @@ describe('PlSqlFormatter', () => {
     `);
   });
 
+  it.only('supports Q custom delimiter strings', () => {
+    expect(format("q'<test string < > 'foo' bar >'")).toBe("q'<test string < > 'foo' bar >'");
+    expect(format("Q'[test string [ ] 'foo' bar ]'")).toBe("Q'[test string [ ] 'foo' bar ]'");
+    expect(format("q'(test string ( ) 'foo' bar )'")).toBe("q'(test string ( ) 'foo' bar )'");
+    expect(format("Q'{test string { } 'foo' bar }'")).toBe("Q'{test string { } 'foo' bar }'");
+    expect(format("q'%test string % % 'foo' bar %'")).toBe("q'%test string % % 'foo' bar %'");
+    expect(format("Q'Xtest string X X 'foo' bar X'")).toBe("Q'Xtest string X X 'foo' bar X'");
+  });
+
   it('formats INSERT without INTO', () => {
     const result = format(
       "INSERT Customers (ID, MoneyBalance, Address, City) VALUES (12,-123.4, 'Skagen 2111','Stv');"

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -93,11 +93,13 @@ describe('PlSqlFormatter', () => {
 
   it('supports Q custom delimiter strings', () => {
     expect(format("q'<test string < > 'foo' bar >'")).toBe("q'<test string < > 'foo' bar >'");
-    expect(format("Q'[test string [ ] 'foo' bar ]'")).toBe("Q'[test string [ ] 'foo' bar ]'");
-    expect(format("q'(test string ( ) 'foo' bar )'")).toBe("q'(test string ( ) 'foo' bar )'");
-    expect(format("Q'{test string { } 'foo' bar }'")).toBe("Q'{test string { } 'foo' bar }'");
-    expect(format("q'%test string % % 'foo' bar %'")).toBe("q'%test string % % 'foo' bar %'");
+    expect(format("NQ'[test string [ ] 'foo' bar ]'")).toBe("NQ'[test string [ ] 'foo' bar ]'");
+    expect(format("nq'(test string ( ) 'foo' bar )'")).toBe("nq'(test string ( ) 'foo' bar )'");
+    expect(format("nQ'{test string { } 'foo' bar }'")).toBe("nQ'{test string { } 'foo' bar }'");
+    expect(format("Nq'%test string % % 'foo' bar %'")).toBe("Nq'%test string % % 'foo' bar %'");
     expect(format("Q'Xtest string X X 'foo' bar X'")).toBe("Q'Xtest string X X 'foo' bar X'");
+    expect(format("q'$test string $'$''")).toBe("q'$test string $' $ ''");
+    expect(format("Q'Stest string S'S''")).toBe("Q'Stest string S' S ''");
   });
 
   it('formats INSERT without INTO', () => {


### PR DESCRIPTION
added support for the 2 cases of PLSQL Q strings:
- special delimiters: <, {, (, [ (must match with the respective >, }, ), ])
- common delimiters: any char that is not the above

surprisingly, the syntax allows for >, }, ), ] to be used as common delimiters
so both `Q'[foobar]'` and `q']foobar]'` are valid

see: https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements003.htm#i42617
for docs