### PR TITLE
Review and revise joins and set operations

### DIFF
--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -106,9 +106,9 @@ const reservedCommands = expandPhrases([
 ]);
 
 const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
+  'UNION {ALL | DISTINCT}',
+  'EXCEPT DISTINCT',
+  'INTERSECT DISTINCT',
 ]);
 
 const reservedJoins = expandPhrases([

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -112,9 +112,9 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
 ]);
 
 // https://cloud.google.com/bigquery/docs/reference/#standard-sql-reference

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -141,11 +141,7 @@ const reservedCommands = [
   'WITH',
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT [ALL]', 'INTERSECT [ALL]']);
 
 const reservedJoins = expandPhrases([
   'JOIN',

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -148,10 +148,9 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
-  'NATURAL JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
 ]);
 
 // https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_72/db2/rbafzintro.htm

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -148,14 +148,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
 ]);

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './db2.functions';
@@ -140,19 +141,13 @@ const reservedCommands = [
   'WITH',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -163,7 +158,7 @@ const reservedJoins = [
   'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
-];
+]);
 
 // https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_72/db2/rbafzintro.htm
 export default class Db2Formatter extends Formatter {

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -43,10 +43,7 @@ const reservedCommands = [
   'ROW FORMAT',
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL | DISTINCT]']);
 
 const reservedJoins = expandPhrases([
   'JOIN',

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -49,14 +49,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
 ]);
 

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './hive.functions';
@@ -42,16 +43,12 @@ const reservedCommands = [
   'ROW FORMAT',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -61,7 +58,7 @@ const reservedJoins = [
   'FULL JOIN',
   'FULL OUTER JOIN',
   'CROSS JOIN',
-];
+]);
 
 // https://cwiki.apache.org/confluence/display/Hive/LanguageManual
 export default class HiveFormatter extends Formatter {

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -49,9 +49,11 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
+  // non-standard joins
+  'LEFT SEMI JOIN',
 ]);
 
 // https://cwiki.apache.org/confluence/display/Hive/LanguageManual

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -232,16 +232,13 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
+  'NATURAL {LEFT | RIGHT} [OUTER] JOIN',
   // non-standard joins
   'STRAIGHT_JOIN',
-  'NATURAL LEFT JOIN',
-  'NATURAL LEFT OUTER JOIN',
-  'NATURAL RIGHT JOIN',
-  'NATURAL RIGHT OUTER JOIN',
 ]);
 
 // For reference: https://mariadb.com/kb/en/sql-statements-structure/

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { EOF_TOKEN, isToken, type Token, TokenType } from 'src/lexer/token';
@@ -223,22 +224,14 @@ const reservedCommands = [
   'WHERE',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-  'MINUS',
-  'MINUS ALL',
-  'MINUS DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+  'MINUS [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -253,7 +246,7 @@ const reservedJoins = [
   'NATURAL LEFT OUTER JOIN',
   'NATURAL RIGHT JOIN',
   'NATURAL RIGHT OUTER JOIN',
-];
+]);
 
 // For reference: https://mariadb.com/kb/en/sql-statements-structure/
 export default class MariaDbFormatter extends Formatter {

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -225,9 +225,9 @@ const reservedCommands = [
 ];
 
 const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
+  'INTERSECT [ALL | DISTINCT]',
   'MINUS [ALL | DISTINCT]',
 ]);
 

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -232,12 +232,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
   // non-standard joins

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -197,11 +197,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL | DISTINCT]']);
 
 const reservedJoins = expandPhrases([
   'JOIN',

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -204,12 +204,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
   // non-standard joins

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -204,16 +204,14 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
+  'NATURAL {LEFT | RIGHT} [OUTER] JOIN',
+  'NATURAL INNER JOIN',
   // non-standard joins
   'STRAIGHT_JOIN',
-  'NATURAL LEFT JOIN',
-  'NATURAL LEFT OUTER JOIN',
-  'NATURAL RIGHT JOIN',
-  'NATURAL RIGHT OUTER JOIN',
 ]);
 
 // https://dev.mysql.com/doc/refman/8.0/en/

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { EOF_TOKEN, isToken, type Token, TokenType } from 'src/lexer/token';
@@ -196,19 +197,13 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -223,7 +218,7 @@ const reservedJoins = [
   'NATURAL LEFT OUTER JOIN',
   'NATURAL RIGHT JOIN',
   'NATURAL RIGHT OUTER JOIN',
-];
+]);
 
 // https://dev.mysql.com/doc/refman/8.0/en/
 export default class MySqlFormatter extends Formatter {

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -65,12 +65,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
-  'MINUS [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT [ALL]', 'INTERSECT [ALL]']);
 
 const reservedJoins = expandPhrases(['JOIN', '{LEFT | RIGHT} [OUTER] JOIN', 'INNER JOIN']);
 

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -72,7 +72,7 @@ const reservedBinaryCommands = expandPhrases([
   'MINUS [ALL | DISTINCT]',
 ]);
 
-const reservedJoins = expandPhrases(['[LEFT | RIGHT] [OUTER] JOIN', 'INNER JOIN']);
+const reservedJoins = expandPhrases(['JOIN', '{LEFT | RIGHT} [OUTER] JOIN', 'INNER JOIN']);
 
 // For reference: http://docs.couchbase.com.s3-website-us-west-1.amazonaws.com/server/6.0/n1ql/n1ql-language-reference/index.html
 export default class N1qlFormatter extends Formatter {

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './n1ql.functions';
@@ -64,29 +65,21 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-  'MINUS',
-  'MINUS ALL',
-  'MINUS DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+  'MINUS [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
   'LEFT OUTER JOIN',
   'RIGHT JOIN',
   'RIGHT OUTER JOIN',
-];
+]);
 
 // For reference: http://docs.couchbase.com.s3-website-us-west-1.amazonaws.com/server/6.0/n1ql/n1ql-language-reference/index.html
 export default class N1qlFormatter extends Formatter {

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -72,14 +72,7 @@ const reservedBinaryCommands = expandPhrases([
   'MINUS [ALL | DISTINCT]',
 ]);
 
-const reservedJoins = expandPhrases([
-  'JOIN',
-  'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-]);
+const reservedJoins = expandPhrases(['[LEFT | RIGHT] [OUTER] JOIN', 'INNER JOIN']);
 
 // For reference: http://docs.couchbase.com.s3-website-us-west-1.amazonaws.com/server/6.0/n1ql/n1ql-language-reference/index.html
 export default class N1qlFormatter extends Formatter {

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -41,13 +41,7 @@ const reservedCommands = [
   'WITH',
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  // set booleans
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
-  'MINUS [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
 
 const reservedJoins = expandPhrases([
   'JOIN',

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -47,16 +47,17 @@ const reservedBinaryCommands = expandPhrases([
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
   'MINUS [ALL | DISTINCT]',
-  // apply
-  'CROSS APPLY',
-  'OUTER APPLY',
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
+  'NATURAL INNER JOIN',
+  'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
+  // non-standard joins
+  '{CROSS | OUTER} APPLY',
 ]);
 
 export default class PlSqlFormatter extends Formatter {

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { EOF_TOKEN, isReserved, isToken, type Token, TokenType } from 'src/lexer/token';
@@ -40,26 +41,18 @@ const reservedCommands = [
   'WITH',
 ];
 
-const reservedBinaryCommands = [
+const reservedBinaryCommands = expandPhrases([
   // set booleans
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-  'MINUS',
-  'MINUS ALL',
-  'MINUS DISTINCT',
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+  'MINUS [ALL | DISTINCT]',
   // apply
   'CROSS APPLY',
   'OUTER APPLY',
-];
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -70,7 +63,7 @@ const reservedJoins = [
   'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
-];
+]);
 
 export default class PlSqlFormatter extends Formatter {
   static operators = [

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -53,14 +53,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
 ]);

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -208,10 +208,9 @@ const reservedCommands = [
 ];
 
 const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
-  'MINUS [ALL | DISTINCT]',
+  'INTERSECT [ALL | DISTINCT]',
 ]);
 
 const reservedJoins = expandPhrases([

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -215,14 +215,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
 ]);

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './postgresql.functions';
@@ -206,22 +207,14 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-  'MINUS',
-  'MINUS ALL',
-  'MINUS DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+  'MINUS [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -232,7 +225,7 @@ const reservedJoins = [
   'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
-];
+]);
 
 const binaryOperators = [
   // Math Operators

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -215,10 +215,12 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
+  'NATURAL INNER JOIN',
+  'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
 ]);
 
 const binaryOperators = [

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './redshift.functions';
@@ -105,19 +106,13 @@ const reservedCommands = [
   'SET SCHEMA', // verify
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -128,7 +123,7 @@ const reservedJoins = [
   'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
-];
+]);
 
 // https://docs.aws.amazon.com/redshift/latest/dg/cm_chap_SQLCommandRef.html
 export default class RedshiftFormatter extends Formatter {

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -113,14 +113,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
 ]);

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -113,10 +113,12 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
+  'NATURAL INNER JOIN',
+  'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
 ]);
 
 // https://docs.aws.amazon.com/redshift/latest/dg/cm_chap_SQLCommandRef.html

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -106,11 +106,7 @@ const reservedCommands = [
   'SET SCHEMA', // verify
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT', 'MINUS']);
 
 const reservedJoins = expandPhrases([
   'JOIN',

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { EOF_TOKEN, isToken, type Token, TokenType } from 'src/lexer/token';
@@ -80,26 +81,18 @@ const reservedCommands = [
   'WINDOW',
 ];
 
-const reservedBinaryCommands = [
+const reservedBinaryCommands = expandPhrases([
   // set booleans
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-  'MINUS',
-  'MINUS ALL',
-  'MINUS DISTINCT',
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+  'MINUS [ALL | DISTINCT]',
   // apply
   'CROSS APPLY',
   'OUTER APPLY',
-];
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -127,7 +120,7 @@ const reservedJoins = [
   'NATURAL RIGHT OUTER JOIN',
   'NATURAL RIGHT SEMI JOIN',
   'NATURAL SEMI JOIN',
-];
+]);
 
 // http://spark.apache.org/docs/latest/sql-programming-guide.html
 export default class SparkFormatter extends Formatter {

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -93,27 +93,15 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
-  // non-standard-joins
-  'ANTI JOIN',
-  'SEMI JOIN',
-  'LEFT ANTI JOIN',
-  'LEFT SEMI JOIN',
-  'RIGHT OUTER JOIN',
-  'RIGHT SEMI JOIN',
-  'NATURAL ANTI JOIN',
-  'NATURAL FULL OUTER JOIN',
   'NATURAL INNER JOIN',
-  'NATURAL LEFT ANTI JOIN',
-  'NATURAL LEFT OUTER JOIN',
-  'NATURAL LEFT SEMI JOIN',
-  'NATURAL OUTER JOIN',
-  'NATURAL RIGHT OUTER JOIN',
-  'NATURAL RIGHT SEMI JOIN',
-  'NATURAL SEMI JOIN',
+  'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
+  // non-standard-joins
+  '[LEFT] {ANTI | SEMI} JOIN',
+  'NATURAL [LEFT] {ANTI | SEMI} JOIN',
 ]);
 
 // http://spark.apache.org/docs/latest/sql-programming-guide.html

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -93,14 +93,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
   // non-standard-joins

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -82,14 +82,9 @@ const reservedCommands = [
 ];
 
 const reservedBinaryCommands = expandPhrases([
-  // set booleans
-  'INTERSECT [ALL | DISTINCT]',
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
-  'MINUS [ALL | DISTINCT]',
-  // apply
-  'CROSS APPLY',
-  'OUTER APPLY',
+  'INTERSECT [ALL | DISTINCT]',
 ]);
 
 const reservedJoins = expandPhrases([

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -42,14 +42,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
 ]);

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -42,10 +42,12 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
+  'NATURAL INNER JOIN',
+  'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
 ]);
 
 export default class SqlFormatter extends Formatter {

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './sql.functions';
@@ -34,19 +35,13 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -57,7 +52,7 @@ const reservedJoins = [
   'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
-];
+]);
 
 export default class SqlFormatter extends Formatter {
   static operators = [];

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -36,9 +36,9 @@ const reservedCommands = [
 ];
 
 const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
+  'INTERSECT [ALL | DISTINCT]',
 ]);
 
 const reservedJoins = expandPhrases([

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -36,11 +36,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
 
 // joins - https://www.sqlite.org/syntax/join-operator.html
 const reservedJoins = expandPhrases([

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -44,9 +44,7 @@ const reservedBinaryCommands = expandPhrases([
 
 // joins - https://www.sqlite.org/syntax/join-operator.html
 const reservedJoins = expandPhrases([
-  'JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
+  '[LEFT] [OUTER] JOIN',
   'INNER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -44,14 +44,12 @@ const reservedBinaryCommands = expandPhrases([
 
 // joins - https://www.sqlite.org/syntax/join-operator.html
 const reservedJoins = expandPhrases([
-  '[LEFT] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
-  'NATURAL LEFT JOIN',
-  'NATURAL LEFT OUTER JOIN',
   'NATURAL INNER JOIN',
-  'NATURAL CROSS JOIN',
+  'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
 ]);
 
 export default class SqliteFormatter extends Formatter {

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './sqlite.functions';
@@ -35,20 +36,14 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+]);
 
 // joins - https://www.sqlite.org/syntax/join-operator.html
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'LEFT JOIN',
   'LEFT OUTER JOIN',
@@ -59,7 +54,7 @@ const reservedJoins = [
   'NATURAL LEFT OUTER JOIN',
   'NATURAL INNER JOIN',
   'NATURAL CROSS JOIN',
-];
+]);
 
 export default class SqliteFormatter extends Formatter {
   // https://www.sqlite.org/lang_expr.html

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -110,17 +110,12 @@ const reservedBinaryCommands = expandPhrases([
 
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L299-L313
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
   'NATURAL JOIN',
   'NATURAL INNER JOIN',
-  'NATURAL LEFT JOIN',
-  'NATURAL LEFT OUTER JOIN',
-  'NATURAL RIGHT JOIN',
-  'NATURAL RIGHT OUTER JOIN',
-  'NATURAL FULL JOIN',
-  'NATURAL FULL OUTER JOIN',
+  'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
 ]);
 
 export default class TrinoFormatter extends Formatter {

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -110,14 +110,8 @@ const reservedBinaryCommands = expandPhrases([
 
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L299-L313
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
   'NATURAL JOIN',
   'NATURAL INNER JOIN',

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './trino.functions';
@@ -100,21 +101,15 @@ const reservedCommands = [
 
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L231-L235
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L288-L291
-const reservedBinaryCommands = [
+const reservedBinaryCommands = expandPhrases([
   // set booleans
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-];
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+]);
 
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L299-L313
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -132,7 +127,7 @@ const reservedJoins = [
   'NATURAL RIGHT OUTER JOIN',
   'NATURAL FULL JOIN',
   'NATURAL FULL OUTER JOIN',
-];
+]);
 
 export default class TrinoFormatter extends Formatter {
   // https://trino.io/docs/current/functions/list.html#id1

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -102,10 +102,9 @@ const reservedCommands = [
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L231-L235
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L288-L291
 const reservedBinaryCommands = expandPhrases([
-  // set booleans
-  'INTERSECT [ALL | DISTINCT]',
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
+  'INTERSECT [ALL | DISTINCT]',
 ]);
 
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L299-L313

--- a/src/languages/tsql/tsql.formatter.ts
+++ b/src/languages/tsql/tsql.formatter.ts
@@ -197,14 +197,8 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  'JOIN',
+  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
   'INNER JOIN',
-  'LEFT JOIN',
-  'LEFT OUTER JOIN',
-  'RIGHT JOIN',
-  'RIGHT OUTER JOIN',
-  'FULL JOIN',
-  'FULL OUTER JOIN',
   'CROSS JOIN',
 ]);
 

--- a/src/languages/tsql/tsql.formatter.ts
+++ b/src/languages/tsql/tsql.formatter.ts
@@ -197,9 +197,11 @@ const reservedBinaryCommands = expandPhrases([
 ]);
 
 const reservedJoins = expandPhrases([
-  '[LEFT | RIGHT | FULL] [OUTER] JOIN',
-  'INNER JOIN',
-  'CROSS JOIN',
+  'JOIN',
+  '{LEFT | RIGHT | FULL} [OUTER] JOIN',
+  '{INNER | CROSS} JOIN',
+  // non-standard joins
+  '{CROSS | OUTER} APPLY',
 ]);
 
 // https://docs.microsoft.com/en-us/sql/t-sql/language-reference?view=sql-server-ver15

--- a/src/languages/tsql/tsql.formatter.ts
+++ b/src/languages/tsql/tsql.formatter.ts
@@ -1,3 +1,4 @@
+import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './tsql.functions';
@@ -188,22 +189,14 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = [
-  'INTERSECT',
-  'INTERSECT ALL',
-  'INTERSECT DISTINCT',
-  'UNION',
-  'UNION ALL',
-  'UNION DISTINCT',
-  'EXCEPT',
-  'EXCEPT ALL',
-  'EXCEPT DISTINCT',
-  'MINUS',
-  'MINUS ALL',
-  'MINUS DISTINCT',
-];
+const reservedBinaryCommands = expandPhrases([
+  'INTERSECT [ALL | DISTINCT]',
+  'UNION [ALL | DISTINCT]',
+  'EXCEPT [ALL | DISTINCT]',
+  'MINUS [ALL | DISTINCT]',
+]);
 
-const reservedJoins = [
+const reservedJoins = expandPhrases([
   'JOIN',
   'INNER JOIN',
   'LEFT JOIN',
@@ -213,7 +206,7 @@ const reservedJoins = [
   'FULL JOIN',
   'FULL OUTER JOIN',
   'CROSS JOIN',
-];
+]);
 
 // https://docs.microsoft.com/en-us/sql/t-sql/language-reference?view=sql-server-ver15
 export default class TSqlFormatter extends Formatter {

--- a/src/languages/tsql/tsql.formatter.ts
+++ b/src/languages/tsql/tsql.formatter.ts
@@ -189,12 +189,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases([
-  'INTERSECT [ALL | DISTINCT]',
-  'UNION [ALL | DISTINCT]',
-  'EXCEPT [ALL | DISTINCT]',
-  'MINUS [ALL | DISTINCT]',
-]);
+const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
 
 const reservedJoins = expandPhrases([
   'JOIN',

--- a/test/behavesLikeMariaDbFormatter.ts
+++ b/test/behavesLikeMariaDbFormatter.ts
@@ -6,7 +6,6 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 import supportsCreateTable from './features/createTable';
 import supportsAlterTable from './features/alterTable';
 import supportsBetween from './features/between';
-import supportsJoin from './features/join';
 import supportsConstraints from './features/constraints';
 import supportsDeleteFrom from './features/deleteFrom';
 import supportsComments from './features/comments';
@@ -27,16 +26,6 @@ export default function behavesLikeMariaDbFormatter(format: FormatFn) {
   supportsAlterTable(format);
   supportsDeleteFrom(format);
   supportsBetween(format);
-  supportsJoin(format, {
-    without: ['FULL'],
-    additionally: [
-      'STRAIGHT_JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-    ],
-  });
   supportsParams(format, { positional: true });
 
   it('allows $ character as part of identifiers', () => {

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -16,6 +16,7 @@ import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('BigQueryFormatter', () => {
   const language = 'bigquery';
@@ -30,6 +31,12 @@ describe('BigQueryFormatter', () => {
   supportsArrayLiterals(format);
   supportsBetween(format);
   supportsJoin(format, { without: ['NATURAL'] });
+  supportsSetOperations(format, [
+    'UNION ALL',
+    'UNION DISTINCT',
+    'EXCEPT DISTINCT',
+    'INTERSECT DISTINCT',
+  ]);
   supportsOperators(format, BigQueryFormatter.operators);
   supportsParams(format, { positional: true, named: ['@'], quoted: ['@``'] });
   supportsWindow(format);

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -29,7 +29,7 @@ describe('BigQueryFormatter', () => {
   supportsIdentifiers(format, ['``']);
   supportsArrayLiterals(format);
   supportsBetween(format);
-  supportsJoin(format, { without: ['NATURAL JOIN'] });
+  supportsJoin(format, { without: ['NATURAL'] });
   supportsOperators(format, BigQueryFormatter.operators);
   supportsParams(format, { positional: true, named: ['@'], quoted: ['@``'] });
   supportsWindow(format);

--- a/test/db2.test.ts
+++ b/test/db2.test.ts
@@ -32,7 +32,7 @@ describe('Db2Formatter', () => {
   supportsBetween(format);
   supportsSchema(format);
   supportsOperators(format, Db2Formatter.operators);
-  supportsJoin(format, { supportsUsing: false });
+  supportsJoin(format, { without: ['NATURAL'], supportsUsing: false });
   supportsParams(format, { positional: true, named: [':'] });
 
   it('formats FETCH FIRST like LIMIT', () => {

--- a/test/db2.test.ts
+++ b/test/db2.test.ts
@@ -16,6 +16,7 @@ import supportsDeleteFrom from './features/deleteFrom';
 import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
+import supportsSetOperations from './features/setOperations';
 
 describe('Db2Formatter', () => {
   const language = 'db2';
@@ -33,6 +34,14 @@ describe('Db2Formatter', () => {
   supportsSchema(format);
   supportsOperators(format, Db2Formatter.operators);
   supportsJoin(format, { without: ['NATURAL'], supportsUsing: false });
+  supportsSetOperations(format, [
+    'UNION',
+    'UNION ALL',
+    'EXCEPT',
+    'EXCEPT ALL',
+    'INTERSECT',
+    'INTERSECT ALL',
+  ]);
   supportsParams(format, { positional: true, named: [':'] });
 
   it('formats FETCH FIRST like LIMIT', () => {

--- a/test/features/join.ts
+++ b/test/features/join.ts
@@ -15,34 +15,17 @@ export default function supportsJoin(
   const unsupportedJoinRegex = without ? new RegExp(without.join('|'), 'u') : /^whateve_!%&$/u;
   const isSupportedJoin = (join: string) => !unsupportedJoinRegex.test(join);
 
-  ['CROSS JOIN', 'NATURAL JOIN'].filter(isSupportedJoin).forEach(join => {
-    it(`supports ${join}`, () => {
-      const result = format(`SELECT * FROM tbl1 ${join} tbl2`);
-      expect(result).toBe(dedent`
-        SELECT
-          *
-        FROM
-          tbl1
-          ${join} tbl2
-      `);
-    });
-  });
-
-  // <join> ::= [ <join type> ] JOIN
-  //
-  // <join type> ::= INNER | <outer join type> [ OUTER ]
-  //
-  // <outer join type> ::= LEFT | RIGHT | FULL
-
   [
     'JOIN',
     'INNER JOIN',
+    'CROSS JOIN',
     'LEFT JOIN',
     'LEFT OUTER JOIN',
     'RIGHT JOIN',
     'RIGHT OUTER JOIN',
     'FULL JOIN',
     'FULL OUTER JOIN',
+    'NATURAL JOIN',
     ...(additionally || []),
   ]
     .filter(isSupportedJoin)

--- a/test/features/join.ts
+++ b/test/features/join.ts
@@ -6,11 +6,12 @@ interface Options {
   without?: string[];
   additionally?: string[];
   supportsUsing?: boolean;
+  supportsApply?: boolean;
 }
 
 export default function supportsJoin(
   format: FormatFn,
-  { without, additionally, supportsUsing = true }: Options = {}
+  { without, additionally, supportsUsing = true, supportsApply }: Options = {}
 ) {
   const unsupportedJoinRegex = without ? new RegExp(without.join('|'), 'u') : /^whateve_!%&$/u;
   const isSupportedJoin = (join: string) => !unsupportedJoinRegex.test(join);
@@ -79,6 +80,22 @@ export default function supportsJoin(
           customers
           JOIN foo USING (id);
       `);
+    });
+  }
+
+  if (supportsApply) {
+    ['CROSS APPLY', 'OUTER APPLY'].forEach(apply => {
+      // TODO: improve formatting of custom functions
+      it(`supports ${apply}`, () => {
+        const result = format(`SELECT * FROM customers ${apply} fn(customers.id)`);
+        expect(result).toBe(dedent`
+          SELECT
+            *
+          FROM
+            customers
+            ${apply} fn (customers.id)
+        `);
+      });
     });
   }
 }

--- a/test/features/join.ts
+++ b/test/features/join.ts
@@ -26,6 +26,13 @@ export default function supportsJoin(
     'FULL JOIN',
     'FULL OUTER JOIN',
     'NATURAL JOIN',
+    'NATURAL INNER JOIN',
+    'NATURAL LEFT JOIN',
+    'NATURAL LEFT OUTER JOIN',
+    'NATURAL RIGHT JOIN',
+    'NATURAL RIGHT OUTER JOIN',
+    'NATURAL FULL JOIN',
+    'NATURAL FULL OUTER JOIN',
     ...(additionally || []),
   ]
     .filter(isSupportedJoin)

--- a/test/features/setOperations.ts
+++ b/test/features/setOperations.ts
@@ -1,0 +1,36 @@
+import dedent from 'dedent-js';
+
+import { FormatFn } from 'src/sqlFormatter';
+
+export const standardSetOperations = [
+  'UNION',
+  'UNION ALL',
+  'UNION DISTINCT',
+  'EXCEPT',
+  'EXCEPT ALL',
+  'EXCEPT DISTINCT',
+  'INTERSECT',
+  'INTERSECT ALL',
+  'INTERSECT DISTINCT',
+];
+
+export default function supportsSetOperations(
+  format: FormatFn,
+  operations: string[] = standardSetOperations
+) {
+  operations.forEach(op => {
+    it(`formats ${op}`, () => {
+      expect(format(`SELECT * FROM foo ${op} SELECT * FROM bar;`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        ${op}
+        SELECT
+          *
+        FROM
+          bar;
+      `);
+    });
+  });
+}

--- a/test/hive.test.ts
+++ b/test/hive.test.ts
@@ -29,7 +29,11 @@ describe('HiveFormatter', () => {
   supportsIdentifiers(format, ['``']);
   supportsBetween(format);
   supportsSchema(format);
-  supportsJoin(format, { without: ['NATURAL JOIN'], supportsUsing: false });
+  supportsJoin(format, {
+    without: ['NATURAL'],
+    additionally: ['LEFT SEMI JOIN'],
+    supportsUsing: false,
+  });
   supportsOperators(format, HiveFormatter.operators);
   supportsArrayAndMapAccessors(format);
   supportsWindow(format);

--- a/test/hive.test.ts
+++ b/test/hive.test.ts
@@ -16,6 +16,7 @@ import supportsArrayAndMapAccessors from './features/arrayAndMapAccessors';
 import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('HiveFormatter', () => {
   const language = 'hive';
@@ -34,6 +35,7 @@ describe('HiveFormatter', () => {
     additionally: ['LEFT SEMI JOIN'],
     supportsUsing: false,
   });
+  supportsSetOperations(format, ['UNION', 'UNION ALL', 'UNION DISTINCT']);
   supportsOperators(format, HiveFormatter.operators);
   supportsArrayAndMapAccessors(format);
   supportsWindow(format);

--- a/test/mariadb.test.ts
+++ b/test/mariadb.test.ts
@@ -13,14 +13,8 @@ describe('MariaDbFormatter', () => {
   behavesLikeMariaDbFormatter(format);
 
   supportsJoin(format, {
-    without: ['FULL'],
-    additionally: [
-      'STRAIGHT_JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-    ],
+    without: ['FULL', 'NATURAL INNER JOIN'],
+    additionally: ['STRAIGHT_JOIN'],
   });
   supportsOperators(format, MariaDbFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsReturning(format);

--- a/test/mariadb.test.ts
+++ b/test/mariadb.test.ts
@@ -2,6 +2,7 @@ import { format as originalFormat, FormatFn } from 'src/sqlFormatter';
 import MariaDbFormatter from 'src/languages/mariadb/mariadb.formatter';
 import behavesLikeMariaDbFormatter from './behavesLikeMariaDbFormatter';
 
+import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsReturning from './features/returning';
 
@@ -11,6 +12,16 @@ describe('MariaDbFormatter', () => {
 
   behavesLikeMariaDbFormatter(format);
 
+  supportsJoin(format, {
+    without: ['FULL'],
+    additionally: [
+      'STRAIGHT_JOIN',
+      'NATURAL LEFT JOIN',
+      'NATURAL LEFT OUTER JOIN',
+      'NATURAL RIGHT JOIN',
+      'NATURAL RIGHT OUTER JOIN',
+    ],
+  });
   supportsOperators(format, MariaDbFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsReturning(format);
 });

--- a/test/mariadb.test.ts
+++ b/test/mariadb.test.ts
@@ -5,6 +5,7 @@ import behavesLikeMariaDbFormatter from './behavesLikeMariaDbFormatter';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsReturning from './features/returning';
+import supportsSetOperations, { standardSetOperations } from './features/setOperations';
 
 describe('MariaDbFormatter', () => {
   const language = 'mariadb';
@@ -16,6 +17,7 @@ describe('MariaDbFormatter', () => {
     without: ['FULL', 'NATURAL INNER JOIN'],
     additionally: ['STRAIGHT_JOIN'],
   });
+  supportsSetOperations(format, [...standardSetOperations, 'MINUS', 'MINUS ALL', 'MINUS DISTINCT']);
   supportsOperators(format, MariaDbFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsReturning(format);
 });

--- a/test/mysql.test.ts
+++ b/test/mysql.test.ts
@@ -4,6 +4,7 @@ import { format as originalFormat, FormatFn } from 'src/sqlFormatter';
 import MySqlFormatter from 'src/languages/mysql/mysql.formatter';
 import behavesLikeMariaDbFormatter from './behavesLikeMariaDbFormatter';
 
+import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsWindow from './features/window';
 
@@ -13,6 +14,17 @@ describe('MySqlFormatter', () => {
 
   behavesLikeMariaDbFormatter(format);
 
+  supportsJoin(format, {
+    without: ['FULL'],
+    additionally: [
+      'STRAIGHT_JOIN',
+      'NATURAL INNER JOIN',
+      'NATURAL LEFT JOIN',
+      'NATURAL LEFT OUTER JOIN',
+      'NATURAL RIGHT JOIN',
+      'NATURAL RIGHT OUTER JOIN',
+    ],
+  });
   supportsOperators(format, MySqlFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsWindow(format);
 

--- a/test/mysql.test.ts
+++ b/test/mysql.test.ts
@@ -16,14 +16,7 @@ describe('MySqlFormatter', () => {
 
   supportsJoin(format, {
     without: ['FULL'],
-    additionally: [
-      'STRAIGHT_JOIN',
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-    ],
+    additionally: ['STRAIGHT_JOIN'],
   });
   supportsOperators(format, MySqlFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsWindow(format);

--- a/test/mysql.test.ts
+++ b/test/mysql.test.ts
@@ -7,6 +7,7 @@ import behavesLikeMariaDbFormatter from './behavesLikeMariaDbFormatter';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('MySqlFormatter', () => {
   const language = 'mysql';
@@ -18,6 +19,7 @@ describe('MySqlFormatter', () => {
     without: ['FULL'],
     additionally: ['STRAIGHT_JOIN'],
   });
+  supportsSetOperations(format, ['UNION', 'UNION ALL', 'UNION DISTINCT']);
   supportsOperators(format, MySqlFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsWindow(format);
 

--- a/test/n1ql.test.ts
+++ b/test/n1ql.test.ts
@@ -17,6 +17,7 @@ import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('N1qlFormatter', () => {
   const language = 'n1ql';
@@ -33,6 +34,14 @@ describe('N1qlFormatter', () => {
   supportsArrayAndMapAccessors(format);
   supportsArrayLiterals(format);
   supportsJoin(format, { without: ['FULL', 'CROSS', 'NATURAL'], supportsUsing: false });
+  supportsSetOperations(format, [
+    'UNION',
+    'UNION ALL',
+    'EXCEPT',
+    'EXCEPT ALL',
+    'INTERSECT',
+    'INTERSECT ALL',
+  ]);
   supportsReturning(format);
   supportsParams(format, { positional: true, numbered: ['$'], named: ['$'] });
   supportsWindow(format);

--- a/test/options/indentStyle.ts
+++ b/test/options/indentStyle.ts
@@ -60,7 +60,7 @@ export default function supportsIndentStyle(format: FormatFn) {
           dedent`
             SELECT *
             FROM a
-            UNION DISTINCT
+            UNION ALL
             SELECT *
             FROM b
             LEFT OUTER JOIN c;
@@ -70,7 +70,7 @@ export default function supportsIndentStyle(format: FormatFn) {
       ).toBe(dedent`
         SELECT    *
         FROM      a
-        UNION     DISTINCT
+        UNION ALL
         SELECT    *
         FROM      b
         LEFT      OUTER JOIN c;
@@ -147,7 +147,7 @@ export default function supportsIndentStyle(format: FormatFn) {
           dedent`
             SELECT *
             FROM a
-            UNION DISTINCT
+            UNION ALL
             SELECT *
             FROM b
             LEFT OUTER JOIN c;
@@ -158,7 +158,7 @@ export default function supportsIndentStyle(format: FormatFn) {
         [
           '   SELECT *',
           '     FROM a',
-          '    UNION DISTINCT',
+          'UNION ALL',
           '   SELECT *',
           '     FROM b',
           '     LEFT OUTER JOIN c;',

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -18,6 +18,7 @@ import supportsDeleteFrom from './features/deleteFrom';
 import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
+import supportsSetOperations from './features/setOperations';
 
 describe('PlSqlFormatter', () => {
   const language = 'plsql';
@@ -36,6 +37,7 @@ describe('PlSqlFormatter', () => {
   supportsSchema(format);
   supportsOperators(format, PlSqlFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsJoin(format, { supportsApply: true });
+  supportsSetOperations(format, ['UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT']);
   supportsReturning(format);
   supportsParams(format, { numbered: [':'], named: [':'] });
 

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -35,7 +35,7 @@ describe('PlSqlFormatter', () => {
   supportsBetween(format);
   supportsSchema(format);
   supportsOperators(format, PlSqlFormatter.operators, ['AND', 'OR', 'XOR']);
-  supportsJoin(format);
+  supportsJoin(format, { supportsApply: true });
   supportsReturning(format);
   supportsParams(format, { numbered: [':'], named: [':'] });
 
@@ -114,36 +114,11 @@ describe('PlSqlFormatter', () => {
     `);
   });
 
-  // TODO: improve formatting of custom functions
-  it('formats SELECT query with CROSS APPLY', () => {
-    const result = format('SELECT a, b FROM t CROSS APPLY fn(t.id)');
-    expect(result).toBe(dedent`
-      SELECT
-        a,
-        b
-      FROM
-        t
-        CROSS APPLY fn (t.id)
-    `);
-  });
-
   it('formats simple SELECT with national characters', () => {
     const result = format("SELECT N'value'");
     expect(result).toBe(dedent`
       SELECT
         N'value'
-    `);
-  });
-
-  it('formats SELECT query with OUTER APPLY', () => {
-    const result = format('SELECT a, b FROM t OUTER APPLY fn(t.id)');
-    expect(result).toBe(dedent`
-      SELECT
-        a,
-        b
-      FROM
-        t
-        OUTER APPLY fn (t.id)
     `);
   });
 

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -133,7 +133,7 @@ describe('PlSqlFormatter', () => {
           tab1
         WHERE
           parent_id IS NULL
-        MINUS
+        UNION
           -- Recursive member.
         SELECT
           t2.id,
@@ -158,7 +158,7 @@ describe('PlSqlFormatter', () => {
             tab1
           WHERE
             parent_id IS NULL
-          MINUS
+          UNION
           -- Recursive member.
           SELECT
             t2.id,
@@ -196,7 +196,7 @@ describe('PlSqlFormatter', () => {
           tab1
         WHERE
           parent_id IS NULL
-        MINUS
+        UNION
           -- Recursive member.
         SELECT
           t2.id,
@@ -221,7 +221,7 @@ describe('PlSqlFormatter', () => {
             tab1
           WHERE
             parent_id IS NULL
-          MINUS
+          UNION
           -- Recursive member.
           SELECT
             t2.id,

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -35,7 +35,17 @@ describe('PlSqlFormatter', () => {
   supportsBetween(format);
   supportsSchema(format);
   supportsOperators(format, PlSqlFormatter.operators, ['AND', 'OR', 'XOR']);
-  supportsJoin(format);
+  supportsJoin(format, {
+    additionally: [
+      'NATURAL INNER JOIN',
+      'NATURAL LEFT JOIN',
+      'NATURAL LEFT OUTER JOIN',
+      'NATURAL RIGHT JOIN',
+      'NATURAL RIGHT OUTER JOIN',
+      'NATURAL FULL JOIN',
+      'NATURAL FULL OUTER JOIN',
+    ],
+  });
   supportsReturning(format);
   supportsParams(format, { numbered: [':'], named: [':'] });
 
@@ -123,8 +133,7 @@ describe('PlSqlFormatter', () => {
         b
       FROM
         t
-      CROSS APPLY
-      fn (t.id)
+        CROSS APPLY fn (t.id)
     `);
   });
 
@@ -144,8 +153,7 @@ describe('PlSqlFormatter', () => {
         b
       FROM
         t
-      OUTER APPLY
-      fn (t.id)
+        OUTER APPLY fn (t.id)
     `);
   });
 

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -35,17 +35,7 @@ describe('PlSqlFormatter', () => {
   supportsBetween(format);
   supportsSchema(format);
   supportsOperators(format, PlSqlFormatter.operators, ['AND', 'OR', 'XOR']);
-  supportsJoin(format, {
-    additionally: [
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-      'NATURAL FULL JOIN',
-      'NATURAL FULL OUTER JOIN',
-    ],
-  });
+  supportsJoin(format);
   supportsReturning(format);
   supportsParams(format, { numbered: [':'], named: [':'] });
 

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -39,7 +39,17 @@ describe('PostgreSqlFormatter', () => {
     format,
     PostgreSqlFormatter.operators.filter(op => op !== '::')
   );
-  supportsJoin(format);
+  supportsJoin(format, {
+    additionally: [
+      'NATURAL INNER JOIN',
+      'NATURAL LEFT JOIN',
+      'NATURAL LEFT OUTER JOIN',
+      'NATURAL RIGHT JOIN',
+      'NATURAL RIGHT OUTER JOIN',
+      'NATURAL FULL JOIN',
+      'NATURAL FULL OUTER JOIN',
+    ],
+  });
   supportsReturning(format);
   supportsParams(format, { numbered: ['$'] });
   supportsWindow(format);

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -19,6 +19,7 @@ import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
 import supportsArrayAndMapAccessors from './features/arrayAndMapAccessors';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('PostgreSqlFormatter', () => {
   const language = 'postgresql';
@@ -40,6 +41,7 @@ describe('PostgreSqlFormatter', () => {
     PostgreSqlFormatter.operators.filter(op => op !== '::')
   );
   supportsJoin(format);
+  supportsSetOperations(format);
   supportsReturning(format);
   supportsParams(format, { numbered: ['$'] });
   supportsWindow(format);

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -39,17 +39,7 @@ describe('PostgreSqlFormatter', () => {
     format,
     PostgreSqlFormatter.operators.filter(op => op !== '::')
   );
-  supportsJoin(format, {
-    additionally: [
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-      'NATURAL FULL JOIN',
-      'NATURAL FULL OUTER JOIN',
-    ],
-  });
+  supportsJoin(format);
   supportsReturning(format);
   supportsParams(format, { numbered: ['$'] });
   supportsWindow(format);

--- a/test/redshift.test.ts
+++ b/test/redshift.test.ts
@@ -30,17 +30,7 @@ describe('RedshiftFormatter', () => {
   supportsIdentifiers(format, [`""`]);
   supportsSchema(format);
   supportsOperators(format, RedshiftFormatter.operators);
-  supportsJoin(format, {
-    additionally: [
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-      'NATURAL FULL JOIN',
-      'NATURAL FULL OUTER JOIN',
-    ],
-  });
+  supportsJoin(format);
   supportsParams(format, { numbered: ['$'] });
 
   it('formats LIMIT', () => {

--- a/test/redshift.test.ts
+++ b/test/redshift.test.ts
@@ -30,7 +30,17 @@ describe('RedshiftFormatter', () => {
   supportsIdentifiers(format, [`""`]);
   supportsSchema(format);
   supportsOperators(format, RedshiftFormatter.operators);
-  supportsJoin(format);
+  supportsJoin(format, {
+    additionally: [
+      'NATURAL INNER JOIN',
+      'NATURAL LEFT JOIN',
+      'NATURAL LEFT OUTER JOIN',
+      'NATURAL RIGHT JOIN',
+      'NATURAL RIGHT OUTER JOIN',
+      'NATURAL FULL JOIN',
+      'NATURAL FULL OUTER JOIN',
+    ],
+  });
   supportsParams(format, { numbered: ['$'] });
 
   it('formats LIMIT', () => {

--- a/test/redshift.test.ts
+++ b/test/redshift.test.ts
@@ -15,6 +15,7 @@ import supportsDeleteFrom from './features/deleteFrom';
 import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
+import supportsSetOperations from './features/setOperations';
 
 describe('RedshiftFormatter', () => {
   const language = 'redshift';
@@ -31,6 +32,7 @@ describe('RedshiftFormatter', () => {
   supportsSchema(format);
   supportsOperators(format, RedshiftFormatter.operators);
   supportsJoin(format);
+  supportsSetOperations(format, ['UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT', 'MINUS']);
   supportsParams(format, { numbered: ['$'] });
 
   it('formats LIMIT', () => {

--- a/test/spark.test.ts
+++ b/test/spark.test.ts
@@ -14,6 +14,7 @@ import supportsStrings from './features/strings';
 import supportsArrayAndMapAccessors from './features/arrayAndMapAccessors';
 import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
+import supportsSetOperations from './features/setOperations';
 
 describe('SparkFormatter', () => {
   const language = 'spark';
@@ -43,6 +44,7 @@ describe('SparkFormatter', () => {
       'NATURAL LEFT SEMI JOIN',
     ],
   });
+  supportsSetOperations(format);
 
   it('formats basic WINDOW clause', () => {
     const result = format(`SELECT * FROM tbl WINDOW win1, WINDOW win2, WINDOW win3;`);

--- a/test/spark.test.ts
+++ b/test/spark.test.ts
@@ -31,13 +31,6 @@ describe('SparkFormatter', () => {
   supportsArrayAndMapAccessors(format);
   supportsJoin(format, {
     additionally: [
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-      'NATURAL FULL JOIN',
-      'NATURAL FULL OUTER JOIN',
       // non-standard anti-join:
       'ANTI JOIN',
       'LEFT ANTI JOIN',

--- a/test/spark.test.ts
+++ b/test/spark.test.ts
@@ -31,22 +31,23 @@ describe('SparkFormatter', () => {
   supportsArrayAndMapAccessors(format);
   supportsJoin(format, {
     additionally: [
-      'ANTI JOIN',
-      'SEMI JOIN',
-      'LEFT ANTI JOIN',
-      'LEFT SEMI JOIN',
-      'RIGHT OUTER JOIN',
-      'RIGHT SEMI JOIN',
-      'NATURAL ANTI JOIN',
-      'NATURAL FULL OUTER JOIN',
       'NATURAL INNER JOIN',
-      'NATURAL LEFT ANTI JOIN',
+      'NATURAL LEFT JOIN',
       'NATURAL LEFT OUTER JOIN',
-      'NATURAL LEFT SEMI JOIN',
-      'NATURAL OUTER JOIN',
+      'NATURAL RIGHT JOIN',
       'NATURAL RIGHT OUTER JOIN',
-      'NATURAL RIGHT SEMI JOIN',
+      'NATURAL FULL JOIN',
+      'NATURAL FULL OUTER JOIN',
+      // non-standard anti-join:
+      'ANTI JOIN',
+      'LEFT ANTI JOIN',
+      'NATURAL ANTI JOIN',
+      'NATURAL LEFT ANTI JOIN',
+      // non-standard semi-join
+      'SEMI JOIN',
+      'LEFT SEMI JOIN',
       'NATURAL SEMI JOIN',
+      'NATURAL LEFT SEMI JOIN',
     ],
   });
 

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -32,17 +32,7 @@ describe('SqlFormatter', () => {
   supportsIdentifiers(format, [`""`, '``']);
   supportsBetween(format);
   supportsSchema(format);
-  supportsJoin(format, {
-    additionally: [
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-      'NATURAL FULL JOIN',
-      'NATURAL FULL OUTER JOIN',
-    ],
-  });
+  supportsJoin(format);
   supportsOperators(format, SqlFormatter.operators);
   supportsParams(format, { positional: true });
   supportsWindow(format);

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -17,6 +17,7 @@ import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('SqlFormatter', () => {
   const language = 'sql';
@@ -33,6 +34,7 @@ describe('SqlFormatter', () => {
   supportsBetween(format);
   supportsSchema(format);
   supportsJoin(format);
+  supportsSetOperations(format);
   supportsOperators(format, SqlFormatter.operators);
   supportsParams(format, { positional: true });
   supportsWindow(format);

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -32,7 +32,17 @@ describe('SqlFormatter', () => {
   supportsIdentifiers(format, [`""`, '``']);
   supportsBetween(format);
   supportsSchema(format);
-  supportsJoin(format);
+  supportsJoin(format, {
+    additionally: [
+      'NATURAL INNER JOIN',
+      'NATURAL LEFT JOIN',
+      'NATURAL LEFT OUTER JOIN',
+      'NATURAL RIGHT JOIN',
+      'NATURAL RIGHT OUTER JOIN',
+      'NATURAL FULL JOIN',
+      'NATURAL FULL OUTER JOIN',
+    ],
+  });
   supportsOperators(format, SqlFormatter.operators);
   supportsParams(format, { positional: true });
   supportsWindow(format);

--- a/test/sqlite.test.ts
+++ b/test/sqlite.test.ts
@@ -17,6 +17,7 @@ import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('SqliteFormatter', () => {
   const language = 'sqlite';
@@ -33,6 +34,7 @@ describe('SqliteFormatter', () => {
   supportsBetween(format);
   supportsSchema(format);
   supportsJoin(format);
+  supportsSetOperations(format, ['UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT']);
   supportsOperators(format, SqliteFormatter.operators);
   supportsParams(format, { positional: true, numbered: ['?'], named: [':', '$', '@'] });
   supportsWindow(format);

--- a/test/sqlite.test.ts
+++ b/test/sqlite.test.ts
@@ -32,17 +32,7 @@ describe('SqliteFormatter', () => {
   supportsIdentifiers(format, [`""`, '``', '[]']);
   supportsBetween(format);
   supportsSchema(format);
-  supportsJoin(format, {
-    additionally: [
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-      'NATURAL FULL JOIN',
-      'NATURAL FULL OUTER JOIN',
-    ],
-  });
+  supportsJoin(format);
   supportsOperators(format, SqliteFormatter.operators);
   supportsParams(format, { positional: true, numbered: ['?'], named: [':', '$', '@'] });
   supportsWindow(format);

--- a/test/sqlite.test.ts
+++ b/test/sqlite.test.ts
@@ -33,8 +33,15 @@ describe('SqliteFormatter', () => {
   supportsBetween(format);
   supportsSchema(format);
   supportsJoin(format, {
-    without: ['FULL', 'RIGHT'],
-    additionally: ['NATURAL LEFT JOIN', 'NATURAL LEFT OUTER JOIN'],
+    additionally: [
+      'NATURAL INNER JOIN',
+      'NATURAL LEFT JOIN',
+      'NATURAL LEFT OUTER JOIN',
+      'NATURAL RIGHT JOIN',
+      'NATURAL RIGHT OUTER JOIN',
+      'NATURAL FULL JOIN',
+      'NATURAL FULL OUTER JOIN',
+    ],
   });
   supportsOperators(format, SqliteFormatter.operators);
   supportsParams(format, { positional: true, numbered: ['?'], named: [':', '$', '@'] });

--- a/test/trino.test.ts
+++ b/test/trino.test.ts
@@ -15,6 +15,7 @@ import supportsArrayAndMapAccessors from './features/arrayAndMapAccessors';
 import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
+import supportsSetOperations from './features/setOperations';
 
 describe('TrinoFormatter', () => {
   const language = 'trino';
@@ -31,6 +32,7 @@ describe('TrinoFormatter', () => {
   supportsArrayLiterals(format);
   supportsArrayAndMapAccessors(format);
   supportsJoin(format);
+  supportsSetOperations(format);
   supportsParams(format, { positional: true });
 
   it('formats SET SESSION', () => {

--- a/test/trino.test.ts
+++ b/test/trino.test.ts
@@ -30,17 +30,7 @@ describe('TrinoFormatter', () => {
   supportsOperators(format, TrinoFormatter.operators, ['AND', 'OR']);
   supportsArrayLiterals(format);
   supportsArrayAndMapAccessors(format);
-  supportsJoin(format, {
-    additionally: [
-      'NATURAL INNER JOIN',
-      'NATURAL LEFT JOIN',
-      'NATURAL LEFT OUTER JOIN',
-      'NATURAL RIGHT JOIN',
-      'NATURAL RIGHT OUTER JOIN',
-      'NATURAL FULL JOIN',
-      'NATURAL FULL OUTER JOIN',
-    ],
-  });
+  supportsJoin(format);
   supportsParams(format, { positional: true });
 
   it('formats SET SESSION', () => {

--- a/test/tsql.test.ts
+++ b/test/tsql.test.ts
@@ -36,7 +36,7 @@ describe('TSqlFormatter', () => {
     format,
     TSqlFormatter.operators.filter(op => op !== '::')
   );
-  supportsJoin(format, { without: ['NATURAL'], supportsUsing: false });
+  supportsJoin(format, { without: ['NATURAL'], supportsUsing: false, supportsApply: true });
   supportsParams(format, { named: ['@'], quoted: ['@""', '@[]'] });
   supportsWindow(format);
 
@@ -51,30 +51,6 @@ describe('TSqlFormatter', () => {
         Customers (ID, MoneyBalance, Address, City)
       VALUES
         (12, -123.4, 'Skagen 2111', 'Stv');
-    `);
-  });
-
-  it('formats SELECT query with CROSS APPLY', () => {
-    const result = format('SELECT a, b FROM t CROSS APPLY fn(t.id)');
-    expect(result).toBe(dedent`
-      SELECT
-        a,
-        b
-      FROM
-        t
-        CROSS APPLY fn (t.id)
-    `);
-  });
-
-  it('formats SELECT query with OUTER APPLY', () => {
-    const result = format('SELECT a, b FROM t OUTER APPLY fn(t.id)');
-    expect(result).toBe(dedent`
-      SELECT
-        a,
-        b
-      FROM
-        t
-        OUTER APPLY fn (t.id)
     `);
   });
 

--- a/test/tsql.test.ts
+++ b/test/tsql.test.ts
@@ -54,15 +54,27 @@ describe('TSqlFormatter', () => {
     `);
   });
 
-  it('formats SELECT query with CROSS JOIN', () => {
-    const result = format('SELECT a, b FROM t CROSS JOIN t2 on t.id = t2.id_t');
+  it('formats SELECT query with CROSS APPLY', () => {
+    const result = format('SELECT a, b FROM t CROSS APPLY fn(t.id)');
     expect(result).toBe(dedent`
       SELECT
         a,
         b
       FROM
         t
-        CROSS JOIN t2 on t.id = t2.id_t
+        CROSS APPLY fn (t.id)
+    `);
+  });
+
+  it('formats SELECT query with OUTER APPLY', () => {
+    const result = format('SELECT a, b FROM t OUTER APPLY fn(t.id)');
+    expect(result).toBe(dedent`
+      SELECT
+        a,
+        b
+      FROM
+        t
+        OUTER APPLY fn (t.id)
     `);
   });
 

--- a/test/tsql.test.ts
+++ b/test/tsql.test.ts
@@ -17,6 +17,7 @@ import supportsComments from './features/comments';
 import supportsIdentifiers from './features/identifiers';
 import supportsParams from './options/param';
 import supportsWindow from './features/window';
+import supportsSetOperations from './features/setOperations';
 
 describe('TSqlFormatter', () => {
   const language = 'tsql';
@@ -37,6 +38,7 @@ describe('TSqlFormatter', () => {
     TSqlFormatter.operators.filter(op => op !== '::')
   );
   supportsJoin(format, { without: ['NATURAL'], supportsUsing: false, supportsApply: true });
+  supportsSetOperations(format, ['UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT']);
   supportsParams(format, { named: ['@'], quoted: ['@""', '@[]'] });
   supportsWindow(format);
 

--- a/test/unit/expandPhrases.test.ts
+++ b/test/unit/expandPhrases.test.ts
@@ -32,9 +32,21 @@ describe('expandSinglePhrase()', () => {
     ]);
   });
 
-  it('expands expression with [multi|choice|block]', () => {
+  it('expands expression with optional [multi|choice|block]', () => {
     expect(expandSinglePhrase('CREATE [TEMP|TEMPORARY|VIRTUAL] TABLE')).toEqual([
       'CREATE TABLE',
+      'CREATE TEMP TABLE',
+      'CREATE TEMPORARY TABLE',
+      'CREATE VIRTUAL TABLE',
+    ]);
+  });
+
+  it('removes braces around {mandatory} {block}', () => {
+    expect(expandSinglePhrase('CREATE {TEMP} {TABLE}')).toEqual(['CREATE TEMP TABLE']);
+  });
+
+  it('expands expression with mandatory {multi|choice|block}', () => {
+    expect(expandSinglePhrase('CREATE {TEMP|TEMPORARY|VIRTUAL} TABLE')).toEqual([
       'CREATE TEMP TABLE',
       'CREATE TEMPORARY TABLE',
       'CREATE VIRTUAL TABLE',
@@ -47,6 +59,15 @@ describe('expandSinglePhrase()', () => {
     );
     expect(() => expandSinglePhrase('CREATE TABLE]')).toThrowErrorMatchingInlineSnapshot(
       `"Unbalanced parenthesis in: CREATE TABLE]"`
+    );
+  });
+
+  it('throws error when encountering unbalanced }{-braces', () => {
+    expect(() => expandSinglePhrase('CREATE {TABLE')).toThrowErrorMatchingInlineSnapshot(
+      `"Unbalanced parenthesis in: CREATE {TABLE"`
+    );
+    expect(() => expandSinglePhrase('CREATE TABLE}')).toThrowErrorMatchingInlineSnapshot(
+      `"Unbalanced parenthesis in: CREATE TABLE}"`
     );
   });
 });


### PR DESCRIPTION
Extended the `expandPhrases()` function with `{FOO | BAR}` syntax.

Used it to generate `JOIN` commands and set operations (`UNION`, `EXCEPT`, ...). Revised these lists based on the docs in wiki, which resulted in removal of support for various types of joins from many dialects. Likely these were there as a result of copy-paste creation of new dialects based on existing ones.

Notably moved `CROSS APPLY` and `OUTER APPLY` out of set operations. They work really more like joins.

Updated tests for joins and added tests for set operations, which previously had none.