### PR TITLE
Delete Branch Naming guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,6 @@
 
 Run `yarn` after checkout to install all dependencies.
 
-## Branch Naming
-
-Please use one of the following prefixes: (ie. feature/new-feature)
-
-- feature/ - development towards a new feature
-- dev/ - misc development not tied to a key feature / refactoring
-- vscode/ - development related to the VSCode Extension
-- issue/ - fix specifically for a issue #
-- bug/ - misc bug fixes not tied to a public issue
-- repo/ - meta dev related changes (ie. typescript, CI/CD, dependencies)
-
 ## Tests
 
 Tests can be run with `yarn test`.


### PR DESCRIPTION
We aren't enforcing these, so no real point of having them.

Less rules FTW :)