### PR TITLE
Rename BINARY_COMMAND to SET_OPERATION

### DIFF
--- a/src/formatter/AliasAs.ts
+++ b/src/formatter/AliasAs.ts
@@ -1,5 +1,5 @@
 import type { AliasMode, FormatOptions } from 'src/types';
-import { isCommand, isToken, type Token, TokenType, EOF_TOKEN, isReserved } from 'src/lexer/token';
+import { isToken, type Token, TokenType, EOF_TOKEN, isReserved } from 'src/lexer/token';
 import AsTokenFactory from './AsTokenFactory';
 
 /** Adds and removes AS tokens as configured by aliasAs option */
@@ -82,7 +82,7 @@ export default class AliasAs {
       token.type === TokenType.IDENTIFIER &&
       (isToken.END(prevToken) ||
         ((prevToken.type === TokenType.IDENTIFIER || prevToken.type === TokenType.NUMBER) &&
-          (nextToken.type === TokenType.COMMA || isCommand(nextToken))))
+          (nextToken.type === TokenType.COMMA || nextToken.type === TokenType.RESERVED_COMMAND)))
     );
   }
 

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -9,7 +9,7 @@ import {
   ArraySubscript,
   AstNode,
   BetweenPredicate,
-  BinaryClause,
+  SetOperation,
   Clause,
   FunctionCall,
   LimitClause,
@@ -68,8 +68,8 @@ export default class ExpressionFormatter {
         case NodeType.clause:
           this.formatClause(node);
           break;
-        case NodeType.binary_clause:
-          this.formatBinaryClause(node);
+        case NodeType.set_operation:
+          this.formatSetOperation(node);
           break;
         case NodeType.limit_clause:
           this.formatLimitClause(node);
@@ -148,7 +148,7 @@ export default class ExpressionFormatter {
     this.layout.indentation.decreaseTopLevel();
   }
 
-  private formatBinaryClause(node: BinaryClause) {
+  private formatSetOperation(node: SetOperation) {
     this.layout.indentation.decreaseTopLevel();
     this.layout.add(WS.NEWLINE, WS.INDENT, this.show(node.nameToken), WS.NEWLINE);
 

--- a/src/formatter/InlineBlock.ts
+++ b/src/formatter/InlineBlock.ts
@@ -39,7 +39,7 @@ export default class InlineBlock {
           break;
         case NodeType.clause:
         case NodeType.limit_clause:
-        case NodeType.binary_clause:
+        case NodeType.set_operation:
           return Infinity;
         case NodeType.all_columns_asterisk:
           length += 1;

--- a/src/formatter/tabularStyle.ts
+++ b/src/formatter/tabularStyle.ts
@@ -33,7 +33,7 @@ export function isTabularToken(token: Token): boolean {
     token.type === TokenType.RESERVED_LOGICAL_OPERATOR ||
     token.type === TokenType.RESERVED_DEPENDENT_CLAUSE ||
     token.type === TokenType.RESERVED_COMMAND ||
-    token.type === TokenType.RESERVED_BINARY_COMMAND ||
+    token.type === TokenType.RESERVED_SET_OPERATION ||
     token.type === TokenType.RESERVED_JOIN
   );
 }

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -105,7 +105,7 @@ const reservedCommands = expandPhrases([
   'EXPORT DATA',
 ]);
 
-const reservedBinaryCommands = expandPhrases([
+const reservedSetOperations = expandPhrases([
   'UNION {ALL | DISTINCT}',
   'EXCEPT DISTINCT',
   'INTERSECT DISTINCT',
@@ -125,7 +125,7 @@ export default class BigQueryFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -141,7 +141,7 @@ const reservedCommands = [
   'WITH',
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT [ALL]', 'INTERSECT [ALL]']);
+const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT [ALL]', 'INTERSECT [ALL]']);
 
 const reservedJoins = expandPhrases([
   'JOIN',
@@ -156,7 +156,7 @@ export default class Db2Formatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE', 'ELSEIF'],
       reservedKeywords: keywords,

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -43,7 +43,7 @@ const reservedCommands = [
   'ROW FORMAT',
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL | DISTINCT]']);
+const reservedSetOperations = expandPhrases(['UNION [ALL | DISTINCT]']);
 
 const reservedJoins = expandPhrases([
   'JOIN',
@@ -60,7 +60,7 @@ export default class HiveFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -224,7 +224,7 @@ const reservedCommands = [
   'WHERE',
 ];
 
-const reservedBinaryCommands = expandPhrases([
+const reservedSetOperations = expandPhrases([
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
   'INTERSECT [ALL | DISTINCT]',
@@ -248,7 +248,7 @@ export default class MariaDbFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE', 'ELSEIF', 'ELSIF'],
       reservedLogicalOperators: ['AND', 'OR', 'XOR'],

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -197,7 +197,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL | DISTINCT]']);
+const reservedSetOperations = expandPhrases(['UNION [ALL | DISTINCT]']);
 
 const reservedJoins = expandPhrases([
   'JOIN',
@@ -217,7 +217,7 @@ export default class MySqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE', 'ELSEIF'],
       reservedLogicalOperators: ['AND', 'OR', 'XOR'],

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -65,7 +65,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT [ALL]', 'INTERSECT [ALL]']);
+const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT [ALL]', 'INTERSECT [ALL]']);
 
 const reservedJoins = expandPhrases(['JOIN', '{LEFT | RIGHT} [OUTER] JOIN', 'INNER JOIN']);
 
@@ -76,7 +76,7 @@ export default class N1qlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedLogicalOperators: ['AND', 'OR', 'XOR'],

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -41,7 +41,7 @@ const reservedCommands = [
   'WITH',
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
+const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
 
 const reservedJoins = expandPhrases([
   'JOIN',
@@ -70,7 +70,7 @@ export default class PlSqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedLogicalOperators: ['AND', 'OR', 'XOR'],

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -207,7 +207,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases([
+const reservedSetOperations = expandPhrases([
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
   'INTERSECT [ALL | DISTINCT]',
@@ -302,7 +302,7 @@ export default class PostgreSqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -106,7 +106,7 @@ const reservedCommands = [
   'SET SCHEMA', // verify
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT', 'MINUS']);
+const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT', 'MINUS']);
 
 const reservedJoins = expandPhrases([
   'JOIN',
@@ -124,7 +124,7 @@ export default class RedshiftFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -81,7 +81,7 @@ const reservedCommands = [
   'WINDOW',
 ];
 
-const reservedBinaryCommands = expandPhrases([
+const reservedSetOperations = expandPhrases([
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
   'INTERSECT [ALL | DISTINCT]',
@@ -106,7 +106,7 @@ export default class SparkFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedLogicalOperators: ['AND', 'OR', 'XOR'],

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -35,7 +35,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases([
+const reservedSetOperations = expandPhrases([
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
   'INTERSECT [ALL | DISTINCT]',
@@ -56,7 +56,7 @@ export default class SqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -36,7 +36,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
+const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
 
 // joins - https://www.sqlite.org/syntax/join-operator.html
 const reservedJoins = expandPhrases([
@@ -55,7 +55,7 @@ export default class SqliteFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -101,7 +101,7 @@ const reservedCommands = [
 
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L231-L235
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L288-L291
-const reservedBinaryCommands = expandPhrases([
+const reservedSetOperations = expandPhrases([
   'UNION [ALL | DISTINCT]',
   'EXCEPT [ALL | DISTINCT]',
   'INTERSECT [ALL | DISTINCT]',
@@ -125,7 +125,7 @@ export default class TrinoFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/languages/tsql/tsql.formatter.ts
+++ b/src/languages/tsql/tsql.formatter.ts
@@ -189,7 +189,7 @@ const reservedCommands = [
   'PARTITION BY',
 ];
 
-const reservedBinaryCommands = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
+const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
 
 const reservedJoins = expandPhrases([
   'JOIN',
@@ -206,7 +206,7 @@ export default class TSqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
       reservedCommands,
-      reservedBinaryCommands,
+      reservedSetOperations,
       reservedJoins,
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedKeywords: keywords,

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -83,7 +83,7 @@ export default class Tokenizer {
         regex: regex.reservedWord(cfg.reservedCommands, cfg.identChars),
         value: v => v.toUpperCase(),
       },
-      [TokenType.RESERVED_BINARY_COMMAND]: {
+      [TokenType.RESERVED_SET_OPERATION]: {
         regex: regex.reservedWord(cfg.reservedSetOperations, cfg.identChars),
         value: v => v.toUpperCase(),
       },

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -13,8 +13,8 @@ interface TokenizerOptions {
   // Keywords in CASE expressions that begin new line, like: WHEN, ELSE
   reservedDependentClauses: string[];
   // Keywords that create newline but no indentaion of their body.
-  // These contain set operations like UNION and various joins like LEFT OUTER JOIN
-  reservedBinaryCommands: string[];
+  // These contain set operations like UNION
+  reservedSetOperations: string[];
   // Various joins like LEFT OUTER JOIN
   reservedJoins: string[];
   // built in function names
@@ -84,7 +84,7 @@ export default class Tokenizer {
         value: v => v.toUpperCase(),
       },
       [TokenType.RESERVED_BINARY_COMMAND]: {
-        regex: regex.reservedWord(cfg.reservedBinaryCommands, cfg.identChars),
+        regex: regex.reservedWord(cfg.reservedSetOperations, cfg.identChars),
         value: v => v.toUpperCase(),
       },
       [TokenType.RESERVED_DEPENDENT_CLAUSE]: {

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -107,7 +107,7 @@ export default class TokenizerEngine {
       this.matchToken(TokenType.RESERVED_CASE_START) ||
       this.matchToken(TokenType.RESERVED_CASE_END) ||
       this.matchToken(TokenType.RESERVED_COMMAND) ||
-      this.matchToken(TokenType.RESERVED_BINARY_COMMAND) ||
+      this.matchToken(TokenType.RESERVED_SET_OPERATION) ||
       this.matchToken(TokenType.RESERVED_DEPENDENT_CLAUSE) ||
       this.matchToken(TokenType.RESERVED_JOIN) ||
       this.matchToken(TokenType.RESERVED_LOGICAL_OPERATOR) ||

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -68,9 +68,8 @@ export const isToken = {
   WITH: testToken({ value: 'WITH', type: TokenType.RESERVED_COMMAND }),
 };
 
-/** Checks if token is a Reserved Command or Reserved set operation */
-export const isCommand = (token: Token): boolean =>
-  token.type === TokenType.RESERVED_COMMAND || token.type === TokenType.RESERVED_SET_OPERATION;
+/** Checks if token is a Reserved Command */
+export const isCommand = (token: Token): boolean => token.type === TokenType.RESERVED_COMMAND;
 
 /** Checks if token is any Reserved Keyword or Command */
 export const isReserved = (token: Token): boolean =>

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -68,9 +68,6 @@ export const isToken = {
   WITH: testToken({ value: 'WITH', type: TokenType.RESERVED_COMMAND }),
 };
 
-/** Checks if token is a Reserved Command */
-export const isCommand = (token: Token): boolean => token.type === TokenType.RESERVED_COMMAND;
-
 /** Checks if token is any Reserved Keyword or Command */
 export const isReserved = (token: Token): boolean =>
   token.type === TokenType.RESERVED_KEYWORD ||

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -8,7 +8,7 @@ export enum TokenType {
   RESERVED_FUNCTION_NAME = 'RESERVED_FUNCTION_NAME',
   RESERVED_LOGICAL_OPERATOR = 'RESERVED_LOGICAL_OPERATOR',
   RESERVED_DEPENDENT_CLAUSE = 'RESERVED_DEPENDENT_CLAUSE',
-  RESERVED_BINARY_COMMAND = 'RESERVED_BINARY_COMMAND',
+  RESERVED_SET_OPERATION = 'RESERVED_SET_OPERATION',
   RESERVED_COMMAND = 'RESERVED_COMMAND',
   RESERVED_JOIN = 'RESERVED_JOIN',
   RESERVED_CASE_START = 'RESERVED_CASE_START',
@@ -68,9 +68,9 @@ export const isToken = {
   WITH: testToken({ value: 'WITH', type: TokenType.RESERVED_COMMAND }),
 };
 
-/** Checks if token is a Reserved Command or Reserved Binary Command */
+/** Checks if token is a Reserved Command or Reserved set operation */
 export const isCommand = (token: Token): boolean =>
-  token.type === TokenType.RESERVED_COMMAND || token.type === TokenType.RESERVED_BINARY_COMMAND;
+  token.type === TokenType.RESERVED_COMMAND || token.type === TokenType.RESERVED_SET_OPERATION;
 
 /** Checks if token is any Reserved Keyword or Command */
 export const isReserved = (token: Token): boolean =>
@@ -79,7 +79,7 @@ export const isReserved = (token: Token): boolean =>
   token.type === TokenType.RESERVED_LOGICAL_OPERATOR ||
   token.type === TokenType.RESERVED_DEPENDENT_CLAUSE ||
   token.type === TokenType.RESERVED_COMMAND ||
-  token.type === TokenType.RESERVED_BINARY_COMMAND ||
+  token.type === TokenType.RESERVED_SET_OPERATION ||
   token.type === TokenType.RESERVED_JOIN ||
   token.type === TokenType.RESERVED_CASE_START ||
   token.type === TokenType.RESERVED_CASE_END;

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -5,7 +5,7 @@ import {
   ArraySubscript,
   AstNode,
   BetweenPredicate,
-  BinaryClause,
+  SetOperation,
   Clause,
   FunctionCall,
   LimitClause,
@@ -54,7 +54,7 @@ export default class Parser {
     return (
       this.limitClause() ||
       this.clause() ||
-      this.binaryClause() ||
+      this.setOperation() ||
       this.functionCall() ||
       this.arraySubscript() ||
       this.parenthesis() ||
@@ -73,11 +73,11 @@ export default class Parser {
     return undefined;
   }
 
-  private binaryClause(): BinaryClause | undefined {
+  private setOperation(): SetOperation | undefined {
     if (this.look().type === TokenType.RESERVED_SET_OPERATION) {
       const name = this.next();
       const children = this.expressionsUntilClauseEnd();
-      return { type: NodeType.binary_clause, nameToken: name, children };
+      return { type: NodeType.set_operation, nameToken: name, children };
     }
     return undefined;
   }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -74,7 +74,7 @@ export default class Parser {
   }
 
   private binaryClause(): BinaryClause | undefined {
-    if (this.look().type === TokenType.RESERVED_BINARY_COMMAND) {
+    if (this.look().type === TokenType.RESERVED_SET_OPERATION) {
       const name = this.next();
       const children = this.expressionsUntilClauseEnd();
       return { type: NodeType.binary_clause, nameToken: name, children };
@@ -176,7 +176,7 @@ export default class Parser {
     const children: AstNode[] = [];
     while (
       this.look().type !== TokenType.RESERVED_COMMAND &&
-      this.look().type !== TokenType.RESERVED_BINARY_COMMAND &&
+      this.look().type !== TokenType.RESERVED_SET_OPERATION &&
       this.look().type !== TokenType.EOF &&
       this.look().type !== TokenType.CLOSE_PAREN &&
       this.look().type !== TokenType.DELIMITER &&

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -3,7 +3,7 @@ import { Token } from 'src/lexer/token';
 export enum NodeType {
   statement = 'statement',
   clause = 'clause',
-  binary_clause = 'binary_clause',
+  set_operation = 'set_operation',
   function_call = 'function_call',
   array_subscript = 'array_subscript',
   parenthesis = 'parenthesis',
@@ -25,8 +25,8 @@ export type Clause = {
   children: AstNode[];
 };
 
-export type BinaryClause = {
-  type: NodeType.binary_clause;
+export type SetOperation = {
+  type: NodeType.set_operation;
   nameToken: Token;
   children: AstNode[];
 };
@@ -82,7 +82,7 @@ export type AllColumnsAsterisk = {
 
 export type AstNode =
   | Clause
-  | BinaryClause
+  | SetOperation
   | FunctionCall
   | ArraySubscript
   | Parenthesis

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -6,7 +6,7 @@ describe('Parser', () => {
     const tokens = new Tokenizer({
       reservedCommands: ['SELECT', 'FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
       reservedDependentClauses: ['WHEN', 'ELSE'],
-      reservedBinaryCommands: ['UNION'],
+      reservedSetOperations: ['UNION'],
       reservedJoins: ['JOIN'],
       reservedKeywords: ['BETWEEN', 'LIKE', 'ON', 'USING'],
       reservedFunctionNames: ['SQRT', 'OFFSET'],


### PR DESCRIPTION
Previously this contained both set operations and joins.

The new name better reflects that it only contains `UNION`, `EXCEPT`, `INTERSECT` and other set operations.

