### PR TITLE
Review of "verify" comments in reservedCommands lists

### DIFF
--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -131,9 +131,9 @@ const reservedCommands = expandPhrases([
   'WHENEVER',
   // other
   'ADD',
-  'ALTER COLUMN', // verify
+  'ALTER COLUMN',
   'AFTER',
-  'DROP TABLE', // verify
+  'DROP TABLE',
   'GO',
   'INSERT INTO',
   'SET CURRENT SCHEMA',

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -28,7 +28,6 @@ const reservedCommands = expandPhrases([
   'CREATE INDEX',
   'CREATE PRIMARY INDEX',
   'CREATE SCOPE',
-  'CREATE TABLE', // verify
   'DELETE',
   'DELETE FROM',
   'DROP COLLECTION',

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -53,7 +53,6 @@ const reservedCommands = expandPhrases([
   'UPDATE STATISTICS',
   'UPSERT',
   // other
-  'DROP TABLE', // verify,
   'INSERT INTO',
   'LET',
   'NEST',

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -22,8 +22,8 @@ const reservedCommands = expandPhrases([
   'ALTER TABLE',
   'BEGIN',
   'CONNECT BY',
-  'CREATE TABLE', // verify
-  'DROP TABLE', // verify
+  'CREATE TABLE',
+  'DROP TABLE',
   'DECLARE',
   'DELETE',
   'DELETE FROM',

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -205,8 +205,8 @@ const reservedCommands = expandPhrases([
   'ADD',
   'AFTER',
   'ALTER COLUMN',
-  'INSERT INTO', // verify
-  'SET SCHEMA', // verify
+  'INSERT INTO',
+  'SET SCHEMA',
 ]);
 
 const reservedSetOperations = expandPhrases([

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -101,10 +101,8 @@ const reservedCommands = expandPhrases([
   'VACUUM',
   'VALUES',
   // other
-  'MODIFY', // verify
-  'INSERT INTO', // verify
-  'ALTER COLUMN', // verify
-  'SET SCHEMA', // verify
+  'INSERT INTO',
+  'ALTER COLUMN',
 ]);
 
 const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT', 'MINUS']);

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -64,7 +64,6 @@ const reservedCommands = expandPhrases([
   'REFRESH FUNCTION',
   'RESET',
   'SET',
-  'SET SCHEMA', // verify
   'SHOW COLUMNS',
   'SHOW CREATE TABLE',
   'SHOW DATABASES',

--- a/src/languages/tsql/tsql.formatter.ts
+++ b/src/languages/tsql/tsql.formatter.ts
@@ -184,9 +184,8 @@ const reservedCommands = expandPhrases([
   'ALTER COLUMN',
   'ALTER TABLE',
   'CREATE TABLE',
-  'INSERT INTO', // verify
-  'DROP TABLE', // verify
-  'SET SCHEMA', // verify
+  'INSERT INTO',
+  'DROP TABLE',
   'VALUES',
 ]);
 

--- a/test/behavesLikeMariaDbFormatter.ts
+++ b/test/behavesLikeMariaDbFormatter.ts
@@ -4,6 +4,7 @@ import { FormatFn } from 'src/sqlFormatter';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsAlterTable from './features/alterTable';
 import supportsBetween from './features/between';
 import supportsConstraints from './features/constraints';
@@ -22,6 +23,7 @@ export default function behavesLikeMariaDbFormatter(format: FormatFn) {
   supportsStrings(format, ["''", '""', "X''"]);
   supportsIdentifiers(format, ['``']);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsConstraints(format);
   supportsAlterTable(format);
   supportsDeleteFrom(format);

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -240,14 +240,6 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
     `);
   });
 
-  it('formats simple DROP query', () => {
-    const result = format('DROP TABLE admin_role;');
-    expect(result).toBe(dedent`
-      DROP TABLE
-        admin_role;
-    `);
-  });
-
   it('formats incomplete query', () => {
     const result = format('SELECT count(');
     expect(result).toBe(dedent`

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -6,6 +6,7 @@ import { flatKeywordList } from 'src/utils';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsStrings from './features/strings';
 import supportsArrayLiterals from './features/arrayLiterals';
 import supportsBetween from './features/between';
@@ -26,6 +27,7 @@ describe('BigQueryFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format, { hashComments: true });
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsDeleteFrom(format);
   supportsStrings(format, ['""', "''"]);
   supportsIdentifiers(format, ['``']);

--- a/test/db2.test.ts
+++ b/test/db2.test.ts
@@ -7,6 +7,7 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 import supportsAlterTable from './features/alterTable';
 import supportsBetween from './features/between';
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsSchema from './features/schema';
@@ -26,6 +27,7 @@ describe('Db2Formatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsConstraints(format);
   supportsAlterTable(format);
   supportsDeleteFrom(format);

--- a/test/features/dropTable.ts
+++ b/test/features/dropTable.ts
@@ -1,0 +1,13 @@
+import dedent from 'dedent-js';
+
+import { FormatFn } from 'src/sqlFormatter';
+
+export default function supportsDropTable(format: FormatFn) {
+  it('formats DROP TABLE statement', () => {
+    const result = format('DROP TABLE admin_role;');
+    expect(result).toBe(dedent`
+      DROP TABLE
+        admin_role;
+    `);
+  });
+}

--- a/test/hive.test.ts
+++ b/test/hive.test.ts
@@ -6,6 +6,7 @@ import HiveFormatter from 'src/languages/hive/hive.formatter';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsAlterTable from './features/alterTable';
 import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
@@ -26,6 +27,7 @@ describe('HiveFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsAlterTable(format);
   supportsStrings(format, ['""', "''"]);
   supportsIdentifiers(format, ['``']);

--- a/test/options/aliasAs.ts
+++ b/test/options/aliasAs.ts
@@ -206,23 +206,6 @@ export default function supportsAliasAs(format: FormatFn) {
       );
     });
 
-    it('does not remove AS keyword when "AS WITH" or "AS ("', () => {
-      const result = format(
-        dedent`CREATE TABLE 'test.example_table' AS WITH cte AS (SELECT a AS alpha)`,
-        { aliasAs: 'never' }
-      );
-
-      expect(result).toBe(dedent`
-        CREATE TABLE
-          'test.example_table' AS
-        WITH
-          cte AS (
-            SELECT
-              a alpha
-          )
-      `);
-    });
-
     it('does not remove AS keywords from CAST(... AS ...)', () => {
       const result = format(
         dedent`SELECT

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -8,6 +8,7 @@ import supportsAlterTable from './features/alterTable';
 import supportsAlterTableModify from './features/alterTableModify';
 import supportsBetween from './features/between';
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsSchema from './features/schema';
@@ -28,6 +29,7 @@ describe('PlSqlFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsConstraints(format);
   supportsAlterTable(format);
   supportsAlterTableModify(format);

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -7,6 +7,7 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 import supportsAlterTable from './features/alterTable';
 import supportsBetween from './features/between';
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsSchema from './features/schema';
@@ -29,6 +30,7 @@ describe('PostgreSqlFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsConstraints(format);
   supportsArrayAndMapAccessors(format);
   supportsAlterTable(format);

--- a/test/redshift.test.ts
+++ b/test/redshift.test.ts
@@ -6,6 +6,7 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsAlterTable from './features/alterTable';
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsStrings from './features/strings';
@@ -23,6 +24,7 @@ describe('RedshiftFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsAlterTable(format);
   supportsDeleteFrom(format);
   supportsStrings(format, ["''"]);

--- a/test/redshift.test.ts
+++ b/test/redshift.test.ts
@@ -5,11 +5,9 @@ import RedshiftFormatter from 'src/languages/redshift/redshift.formatter';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsAlterTable from './features/alterTable';
-import supportsAlterTableModify from './features/alterTableModify';
 import supportsCreateTable from './features/createTable';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
-import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 import supportsDeleteFrom from './features/deleteFrom';
 import supportsComments from './features/comments';
@@ -26,11 +24,9 @@ describe('RedshiftFormatter', () => {
   supportsComments(format);
   supportsCreateTable(format);
   supportsAlterTable(format);
-  supportsAlterTableModify(format);
   supportsDeleteFrom(format);
   supportsStrings(format, ["''"]);
   supportsIdentifiers(format, [`""`]);
-  supportsSchema(format);
   supportsOperators(format, RedshiftFormatter.operators);
   supportsJoin(format);
   supportsSetOperations(format, ['UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT', 'MINUS']);

--- a/test/spark.test.ts
+++ b/test/spark.test.ts
@@ -9,7 +9,6 @@ import supportsBetween from './features/between';
 import supportsCreateTable from './features/createTable';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
-import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 import supportsArrayAndMapAccessors from './features/arrayAndMapAccessors';
 import supportsComments from './features/comments';
@@ -28,7 +27,6 @@ describe('SparkFormatter', () => {
   supportsStrings(format, ["''", "X''"]);
   supportsIdentifiers(format, ['``']);
   supportsBetween(format);
-  supportsSchema(format);
   supportsOperators(format, SparkFormatter.operators, ['AND', 'OR', 'XOR']);
   supportsArrayAndMapAccessors(format);
   supportsJoin(format, {

--- a/test/spark.test.ts
+++ b/test/spark.test.ts
@@ -7,6 +7,7 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 import supportsAlterTable from './features/alterTable';
 import supportsBetween from './features/between';
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 import supportsStrings from './features/strings';
@@ -23,6 +24,7 @@ describe('SparkFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsAlterTable(format);
   supportsStrings(format, ["''", "X''"]);
   supportsIdentifiers(format, ['``']);

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -5,6 +5,7 @@ import SqlFormatter from 'src/languages/sql/sql.formatter';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsAlterTable from './features/alterTable';
 import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
@@ -27,6 +28,7 @@ describe('SqlFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsConstraints(format);
   supportsAlterTable(format);
   supportsDeleteFrom(format);

--- a/test/sqlite.test.ts
+++ b/test/sqlite.test.ts
@@ -3,6 +3,7 @@ import SqliteFormatter from 'src/languages/sqlite/sqlite.formatter';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsAlterTable from './features/alterTable';
 import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
@@ -25,6 +26,7 @@ describe('SqliteFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsConstraints(format);
   supportsAlterTable(format);
   supportsDeleteFrom(format);

--- a/test/trino.test.ts
+++ b/test/trino.test.ts
@@ -7,6 +7,7 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 import supportsArrayLiterals from './features/arrayLiterals';
 import supportsBetween from './features/between';
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsDeleteFrom from './features/deleteFrom';
 import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
@@ -26,6 +27,7 @@ describe('TrinoFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsDeleteFrom(format);
   supportsStrings(format, ["''", "X''", "U&''"]);
   supportsIdentifiers(format, ['""']);

--- a/test/tsql.test.ts
+++ b/test/tsql.test.ts
@@ -6,7 +6,6 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsCreateTable from './features/createTable';
 import supportsAlterTable from './features/alterTable';
-import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 import supportsBetween from './features/between';
 import supportsOperators from './features/operators';
@@ -33,7 +32,6 @@ describe('TSqlFormatter', () => {
   supportsStrings(format, ["N''", "''"]);
   supportsIdentifiers(format, [`""`, '[]']);
   supportsBetween(format);
-  supportsSchema(format);
   supportsOperators(
     format,
     TSqlFormatter.operators.filter(op => op !== '::')

--- a/test/tsql.test.ts
+++ b/test/tsql.test.ts
@@ -5,6 +5,7 @@ import TSqlFormatter from 'src/languages/tsql/tsql.formatter';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsCreateTable from './features/createTable';
+import supportsDropTable from './features/dropTable';
 import supportsAlterTable from './features/alterTable';
 import supportsStrings from './features/strings';
 import supportsBetween from './features/between';
@@ -26,6 +27,7 @@ describe('TSqlFormatter', () => {
   behavesLikeSqlFormatter(format);
   supportsComments(format);
   supportsCreateTable(format);
+  supportsDropTable(format);
   supportsConstraints(format);
   supportsAlterTable(format);
   supportsDeleteFrom(format);


### PR DESCRIPTION
One notable change: dropped support for `CREATE TABLE` and `DROP TABLE` from N1QL.

As a result had to reorganize some tests, as we were assuming these statements are supported by all dialects.