### PR TITLE
Fix isToken.SELECT predicate

### DIFF
--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -61,7 +61,8 @@ export const isToken = {
   END: testToken({ value: 'END', type: TokenType.RESERVED_CASE_END }),
   FROM: testToken({ value: 'FROM', type: TokenType.RESERVED_COMMAND }),
   LIMIT: testToken({ value: 'LIMIT', type: TokenType.RESERVED_COMMAND }),
-  SELECT: testToken({ value: 'SELECT', type: TokenType.RESERVED_COMMAND }),
+  SELECT: (token: Token) =>
+    /^SELECT\b/.test(token.value) && token.type === TokenType.RESERVED_COMMAND,
   SET: testToken({ value: 'SET', type: TokenType.RESERVED_COMMAND }),
   STRUCT: testToken({ value: 'STRUCT', type: TokenType.RESERVED_KEYWORD }),
   TABLE: testToken({ value: 'TABLE', type: TokenType.RESERVED_KEYWORD }),

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -4,7 +4,7 @@ import Tokenizer from 'src/lexer/Tokenizer';
 describe('Parser', () => {
   const parse = (sql: string) => {
     const tokens = new Tokenizer({
-      reservedCommands: ['SELECT', 'FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
+      reservedCommands: ['SELECT', 'SELECT DISTINCT', 'FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
       reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedSetOperations: ['UNION'],
       reservedJoins: ['JOIN'],
@@ -382,6 +382,32 @@ describe('Parser', () => {
                 "text": "SELECT",
                 "type": "RESERVED_COMMAND",
                 "value": "SELECT",
+              },
+              "type": "clause",
+            },
+          ],
+          "hasSemicolon": false,
+          "type": "statement",
+        },
+      ]
+    `);
+  });
+
+  it('parses SELECT DISTINCT *', () => {
+    expect(parse('SELECT DISTINCT *')).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "all_columns_asterisk",
+                },
+              ],
+              "nameToken": Object {
+                "text": "SELECT DISTINCT",
+                "type": "RESERVED_COMMAND",
+                "value": "SELECT DISTINCT",
               },
               "type": "clause",
             },


### PR DESCRIPTION
Fixing the SELECT clause detection.

A bit of a step-back from having previously eliminated the need to compare keywords with regexes. Another sign that this one-token-can-contain-multiple-words is not really a proper path forward.

