### PR TITLE
Update VSCode Extension for v9.x

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [1.2.0] - 2022-08-09
+
+- updated `sql-formatter` to v9.x
+- removed `aliasAS`
+- added `trino` (aka presto) as new supported dialect
+
 ## [1.1.1] - 2022-07-05
 
 - updated package metadata to point at `sql-formatter` instead of `prettier-sql`

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -24,8 +24,6 @@ Use the FORMATTING template if it is an issue related the formatting of the SQL,
 
 `Prettier-SQL.logicalOperatorNewline`: Whether to break before or after AND and OR
 
-`Prettier-SQL.aliasAS`: Where to use AS in column or table aliases
-
 `Prettier-SQL.tabulateAlias`: Whether to right-align aliases to the longest line in the SELECT clause
 
 `Prettier-SQL.commaPosition`: Where to place commas for SELECT and GROUP BY clauses

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -178,23 +178,6 @@
           "default": "before",
           "markdownDescription": "Whether to break before or after AND and OR"
         },
-        "Prettier-SQL.aliasAS": {
-          "type": "string",
-          "enum": [
-            "preserve",
-            "always",
-            "select",
-            "never"
-          ],
-          "enumDescriptions": [
-            "Preserve existing AS usage",
-            "Use AS in SELECT clauses and for tables",
-            "Use AS only in SELECT clauses",
-            "Do not use AS for aliases"
-          ],
-          "default": "preserve",
-          "markdownDescription": "Where to use AS in column or table aliases"
-        },
         "Prettier-SQL.tabulateAlias": {
           "type": "boolean",
           "default": false,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "prettier-sql-vscode",
   "displayName": "Prettier SQL VSCode",
   "description": "VSCode Extension to format SQL files",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "publisher": "inferrinizzard",
   "author": {
     "name": "inferrinizzard"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -37,6 +37,7 @@
     "pl/sql",
     "postgres",
     "postgresql",
+    "presto",
     "prettier",
     "redshift",
     "spark",
@@ -44,6 +45,7 @@
     "sql",
     "sqlite",
     "sql server",
+    "trino",
     "tsql"
   ],
   "activationEvents": [
@@ -123,6 +125,7 @@
             "redshift",
             "spark",
             "sqlite",
+            "trino",
             "tsql"
           ],
           "default": "sql",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -67,7 +67,7 @@
     "vsce:publish": "vsce publish"
   },
   "dependencies": {
-    "sql-formatter": "^8.2.0"
+    "sql-formatter": "^9.0.0"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -4,7 +4,6 @@ import type {
   SqlLanguage,
   KeywordCase,
   IndentStyle,
-  AliasMode,
   CommaPosition,
   LogicalOperatorNewline,
 } from 'sql-formatter';
@@ -33,7 +32,6 @@ const getConfigs = (
     keywordCase: settings.get<KeywordCase>('keywordCase'),
     indentStyle: settings.get<IndentStyle>('indentStyle'),
     logicalOperatorNewline: settings.get<LogicalOperatorNewline>('logicalOperatorNewline'),
-    aliasAs: settings.get<AliasMode>('aliasAS'),
     tabulateAlias: settings.get<boolean>('tabulateAlias'),
     commaPosition: settings.get<CommaPosition>('commaPosition'),
     expressionWidth: settings.get<number>('expressionWidth'),

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -1889,10 +1889,10 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-sql-formatter@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.2.0.tgz#2b664f02bb6b7bb6fcad1346e850b8f583303469"
-  integrity sha512-5hQOSOk8jfhPkNgUmpm+9Fn2aaLWcf4vKL/dIvUN5q9rsamKHSyN/gL79xpkETNOyL+Zv5BMQfA7z9Rmz/DJJg==
+sql-formatter@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-9.0.0.tgz#e37bee07ae371acd37172079538dc92c48795312"
+  integrity sha512-UVwpc4PkgavuvufdDv0IsA2XwCYnISPaNYabCpGJSOPBoN7SytvRo0iCgLAV1NJEoDqzrzAOZYyCo47lfrV4mA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
- removed `aliasAs`
- added trino as new dialect
- upgraded sql-formatter to v9.x