### PR TITLE
Throw error when unsupported aliasAs config used

### DIFF
--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -89,6 +89,9 @@ function validateConfig(cfg: FormatOptions): FormatOptions {
   if ('newlineBeforeCloseParen' in cfg) {
     throw new ConfigError('newlineBeforeCloseParen config is no more supported.');
   }
+  if ('aliasAs' in cfg) {
+    throw new ConfigError('aliasAs config is no more supported.');
+  }
 
   if (cfg.expressionWidth <= 0) {
     throw new ConfigError(

--- a/test/sqlFormatter.test.ts
+++ b/test/sqlFormatter.test.ts
@@ -42,4 +42,10 @@ describe('sqlFormatter', () => {
       format('SELECT *', { newlineBeforeCloseParen: true } as any);
     }).toThrow('newlineBeforeCloseParen config is no more supported.');
   });
+
+  it('throws error when aliasAs config option used', () => {
+    expect(() => {
+      format('SELECT *', { aliasAs: 'always' } as any);
+    }).toThrow('aliasAs config is no more supported.');
+  });
 });


### PR DESCRIPTION
Forgot to add this check when I originally removed the `aliasAs` config.