### PR TITLE
Prefer i-modifier over case-insensitive regex transform

### DIFF
--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -38,11 +38,11 @@ export default class Tokenizer {
           /(?:0x[0-9a-fA-F]+|0b[01]+|(?:-\s*)?[0-9]+(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+(?:\.[0-9]+)?)?)(?!\w)/uy,
       },
       [TokenType.RESERVED_CASE_START]: {
-        regex: /[Cc][Aa][Ss][Ee]\b/uy,
+        regex: /CASE\b/iuy,
         value: v => equalizeWhitespace(v.toUpperCase()),
       },
       [TokenType.RESERVED_CASE_END]: {
-        regex: /[Ee][Nn][Dd]\b/uy,
+        regex: /END\b/iuy,
         value: v => equalizeWhitespace(v.toUpperCase()),
       },
       [TokenType.RESERVED_COMMAND]: {

--- a/src/lexer/regexFactory.ts
+++ b/src/lexer/regexFactory.ts
@@ -6,7 +6,6 @@ import {
   escapeRegExp,
   patternToRegex,
   prefixesPattern,
-  toCaseInsensitivePattern,
   withDashes,
 } from './regexUtil';
 
@@ -55,7 +54,6 @@ export const reservedWord = (reservedKeywords: string[], identChars: IdentChars 
   const avoidIdentChars = rejectIdentCharsPattern(identChars);
 
   const reservedKeywordsPattern = sortByLengthDesc(reservedKeywords)
-    .map(toCaseInsensitivePattern)
     .join('|')
     .replace(/ /gu, '\\s+');
 


### PR DESCRIPTION
Discovered that we're applying the `toCaseInsensitivePattern` function to all our keywords instead of simply using the `i` modifier. Similarly for some reason the `CASE` and `END` keywords were encoded using `[Cc][Aa]...`.

Compared performance with [jsben.ch](https://jsben.ch/) before and after and saw a noticeable performance improvement:

- 50% faster in Firefox
- 50% faster in Chrome
- no difference in Safari