### PR TITLE
Change BetweenPredicate node field types

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -120,16 +120,11 @@ export default class ExpressionFormatter {
   }
 
   private formatBetweenPredicate(node: BetweenPredicate) {
-    this.layout.add(
-      this.show(node.betweenToken),
-      WS.SPACE,
-      this.show(node.expr1),
-      WS.SPACE,
-      this.showNonTabular(node.andToken),
-      WS.SPACE,
-      this.show(node.expr2),
-      WS.SPACE
-    );
+    this.layout.add(this.show(node.betweenToken), WS.SPACE);
+    this.layout = this.formatSubExpression(node.expr1);
+    this.layout.add(WS.NO_SPACE, WS.SPACE, this.showNonTabular(node.andToken), WS.SPACE);
+    this.layout = this.formatSubExpression(node.expr2);
+    this.layout.add(WS.SPACE);
   }
 
   private formatClause(node: Clause) {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -130,9 +130,9 @@ export default class Parser {
       return {
         type: NodeType.between_predicate,
         betweenToken: this.next(),
-        expr1: this.next(),
+        expr1: [this.nextTokenNode()],
         andToken: this.next(),
-        expr2: this.next(),
+        expr2: [this.nextTokenNode()],
       };
     }
     return undefined;

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -61,9 +61,9 @@ export type Parenthesis = {
 export type BetweenPredicate = {
   type: NodeType.between_predicate;
   betweenToken: Token;
-  expr1: Token;
+  expr1: AstNode[];
   andToken: Token;
-  expr2: Token;
+  expr2: AstNode[];
 };
 
 // LIMIT <count>

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -321,22 +321,32 @@ describe('Parser', () => {
                     "text": "BETWEEN",
                     "type": "BETWEEN",
                   },
-                  "expr1": Object {
-                    "end": 20,
-                    "precedingWhitespace": " ",
-                    "raw": "10",
-                    "start": 18,
-                    "text": "10",
-                    "type": "NUMBER",
-                  },
-                  "expr2": Object {
-                    "end": 27,
-                    "precedingWhitespace": " ",
-                    "raw": "15",
-                    "start": 25,
-                    "text": "15",
-                    "type": "NUMBER",
-                  },
+                  "expr1": Array [
+                    Object {
+                      "token": Object {
+                        "end": 20,
+                        "precedingWhitespace": " ",
+                        "raw": "10",
+                        "start": 18,
+                        "text": "10",
+                        "type": "NUMBER",
+                      },
+                      "type": "token",
+                    },
+                  ],
+                  "expr2": Array [
+                    Object {
+                      "token": Object {
+                        "end": 27,
+                        "precedingWhitespace": " ",
+                        "raw": "15",
+                        "start": 25,
+                        "text": "15",
+                        "type": "NUMBER",
+                      },
+                      "type": "token",
+                    },
+                  ],
                   "type": "between_predicate",
                 },
               ],


### PR DESCRIPTION
To be consistent with other AST nodes.

Discovered while working with Nearley that BetweenPredicate type expects single tokens as its sub-expressions:

```ts
type BetweenPredicate = {
  type: NodeType.between_predicate;
  betweenToken: Token;
  expr1: Token;
  andToken: Token;
  expr2: Token;
};
```

But we really want this:

```ts
type BetweenPredicate = {
  type: NodeType.between_predicate;
  betweenToken: Token;
  expr1: AstNode[];
  andToken: Token;
  expr2: AstNode[];
};
```

Already implemented it in Nearley branch the latter way, as that was a natural way to express it.