### PR TITLE
Extract parse() method inside Formatter

### DIFF
--- a/src/formatter/Formatter.ts
+++ b/src/formatter/Formatter.ts
@@ -46,12 +46,16 @@ export default class Formatter {
    * @return {string} The formatter query
    */
   public format(query: string): string {
-    const tokens = this.cachedTokenizer().tokenize(query, this.cfg.paramTypes || {});
-    const ast = new Parser(tokens).parse();
+    const ast = this.parse(query);
     const formattedQuery = this.formatAst(ast);
     const finalQuery = this.postFormat(formattedQuery);
 
     return finalQuery.trimEnd();
+  }
+
+  private parse(query: string): Statement[] {
+    const tokens = this.cachedTokenizer().tokenize(query, this.cfg.paramTypes || {});
+    return new Parser(tokens).parse();
   }
 
   private formatAst(statements: Statement[]): string {


### PR DESCRIPTION
A very minor change in Formatter class, to aid with changes in Nearley branch.

But perfectly applicable to `master` as well.

I'll merge this straight in as it's really a trivial change.