### PR TITLE
Remove braces and brackets from operators

### DIFF
--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -106,7 +106,7 @@ export default class Tokenizer {
       },
       [TokenType.DELIMITER]: { regex: /[;]/uy },
       [TokenType.OPERATOR]: {
-        regex: regex.operator('+-/%&|^><=.:$@#?~![]{}', [
+        regex: regex.operator('+-/%&|^><=.:$@#?~!', [
           '<>',
           '<=',
           '>=',

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -60,15 +60,23 @@ describe('SqlFormatter', () => {
   it('does not crash when encountering characters or operators it does not recognize', () => {
     expect(
       format(`
-        SELECT @name, :bar FROM {foo};
+        SELECT @name, :bar FROM foo;
       `)
     ).toBe(dedent`
       SELECT
         @ name,
       : bar
       FROM
-        { foo };
+        foo;
     `);
+  });
+
+  it('crashes when encountering unsupported curly braces', () => {
+    expect(() =>
+      format(`
+        SELECT {foo};
+      `)
+    ).toThrowError('Parse error: Unexpected "{foo};');
   });
 
   it('formats ALTER TABLE ... ALTER COLUMN', () => {


### PR DESCRIPTION
Another small thing I discovered when working with Nearley integration.

This can cause ambiguity in parser, and really they shouldn't have been there in the first place.

This is somewhat of a breaking change, in a sense that code that got previously formatted without crashing will now cause an error to be thrown. But that'll only effect you when you used a `langauge` option that didn't support curly-bracws/square-brackets to parse code which contained them.