### PR TITLE
Remove unnecessary type imports

### DIFF
--- a/src/FormatOptions.ts
+++ b/src/FormatOptions.ts
@@ -1,5 +1,6 @@
+// import only type to avoid ESLint no-cycle rule producing an error
 import type { SqlLanguage } from './sqlFormatter';
-import { type ParamItems } from './formatter/Params';
+import { ParamItems } from './formatter/Params';
 import Formatter from './formatter/Formatter';
 import { ParamTypes } from './lexer/TokenizerOptions';
 

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -1,4 +1,4 @@
-import type { FormatOptions } from 'src/FormatOptions';
+import { FormatOptions } from 'src/FormatOptions';
 import { equalizeWhitespace } from 'src/utils';
 
 import Params from 'src/formatter/Params';

--- a/src/formatter/Formatter.ts
+++ b/src/formatter/Formatter.ts
@@ -1,4 +1,4 @@
-import type { FormatOptions } from 'src/FormatOptions';
+import { FormatOptions } from 'src/FormatOptions';
 import { indentString } from 'src/formatter/config';
 import Params from 'src/formatter/Params';
 import Tokenizer from 'src/lexer/Tokenizer';

--- a/src/formatter/config.ts
+++ b/src/formatter/config.ts
@@ -1,4 +1,4 @@
-import type { FormatOptions } from 'src/FormatOptions';
+import { FormatOptions } from 'src/FormatOptions';
 
 // Utility functions for config options
 

--- a/src/formatter/formatCommaPositions.ts
+++ b/src/formatter/formatCommaPositions.ts
@@ -1,4 +1,4 @@
-import type { CommaPosition } from 'src/FormatOptions';
+import { CommaPosition } from 'src/FormatOptions';
 import { maxLength } from 'src/utils';
 
 const PRECEDING_WHITESPACE_REGEX = /^\s+/u;

--- a/src/formatter/tabularStyle.ts
+++ b/src/formatter/tabularStyle.ts
@@ -1,4 +1,4 @@
-import type { IndentStyle } from 'src/FormatOptions';
+import { IndentStyle } from 'src/FormatOptions';
 import { isLogicalOperator, TokenType } from 'src/lexer/token';
 
 /**

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -1,6 +1,6 @@
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
-import { EOF_TOKEN, isToken, TokenType, type Token } from 'src/lexer/token';
+import { EOF_TOKEN, isToken, TokenType, Token } from 'src/lexer/token';
 import { expandPhrases } from 'src/expandPhrases';
 import { keywords } from './bigquery.keywords';
 import { functions } from './bigquery.functions';

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -1,7 +1,7 @@
 import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
-import { EOF_TOKEN, isToken, type Token, TokenType } from 'src/lexer/token';
+import { EOF_TOKEN, isToken, Token, TokenType } from 'src/lexer/token';
 import { keywords } from './mariadb.keywords';
 import { functions } from './mariadb.functions';
 

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -1,7 +1,7 @@
 import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
-import { EOF_TOKEN, isToken, type Token, TokenType } from 'src/lexer/token';
+import { EOF_TOKEN, isToken, Token, TokenType } from 'src/lexer/token';
 import { keywords } from './mysql.keywords';
 import { functions } from './mysql.functions';
 

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -1,7 +1,7 @@
 import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
-import { EOF_TOKEN, isReserved, isToken, type Token, TokenType } from 'src/lexer/token';
+import { EOF_TOKEN, isReserved, isToken, Token, TokenType } from 'src/lexer/token';
 import { keywords } from './plsql.keywords';
 import { functions } from './plsql.functions';
 

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -1,7 +1,7 @@
 import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
-import { EOF_TOKEN, isToken, type Token, TokenType } from 'src/lexer/token';
+import { EOF_TOKEN, isToken, Token, TokenType } from 'src/lexer/token';
 import { keywords } from './singlestoredb.keywords';
 import { functions } from './singlestoredb.functions';
 

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -1,7 +1,7 @@
 import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
-import { EOF_TOKEN, isToken, type Token, TokenType } from 'src/lexer/token';
+import { EOF_TOKEN, isToken, Token, TokenType } from 'src/lexer/token';
 import { keywords } from './spark.keywords';
 import { functions } from './spark.functions';
 

--- a/src/lexer/regexFactory.ts
+++ b/src/lexer/regexFactory.ts
@@ -1,6 +1,6 @@
 import { sortByLengthDesc } from 'src/utils';
 
-import type { IdentChars, QuoteType, VariableType } from './TokenizerOptions';
+import { IdentChars, QuoteType, VariableType } from './TokenizerOptions';
 import {
   escapeParen,
   escapeRegExp,

--- a/src/lexer/regexUtil.ts
+++ b/src/lexer/regexUtil.ts
@@ -1,4 +1,4 @@
-import type { PrefixedQuoteType } from './TokenizerOptions';
+import { PrefixedQuoteType } from './TokenizerOptions';
 
 // Escapes regex special chars
 export const escapeRegExp = (string: string) => string.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -14,7 +14,7 @@ import TrinoFormatter from 'src/languages/trino/trino.formatter';
 import TSqlFormatter from 'src/languages/tsql/tsql.formatter';
 import SingleStoreDbFormatter from './languages/singlestoredb/singlestoredb.formatter';
 
-import type { FormatOptions } from './FormatOptions';
+import { FormatOptions } from './FormatOptions';
 import { ParamItems } from './formatter/Params';
 
 export const formatters = {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { format } from 'sql-formatter';
 import {
+  format,
   SqlLanguage,
   KeywordCase,
   IndentStyle,

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { format } from 'sql-formatter';
-import type {
+import {
   SqlLanguage,
   KeywordCase,
   IndentStyle,


### PR DESCRIPTION
I suspect these type-only imports were added to deal with cyclic dependencies for which ESLint `no-cycle` rule will throw an error. I think the `no-cycle` rule is worth having as cyclic dependencies can indeed cause problems at runtime. They won't be problem with types, as these will get compiled away, so the solution to use `import type` is IMHO a valid one.

This leaves only one such import, for which I also added a comment to explain why we're using it.

Another reason to `import type` would be if we wanted to only import e.g. a type of a class, but for some reason not the class implementation itself. I don't think we have any such uses.

This PR also eliminates all uses of `import { type Foo }` syntax, which makes the library compatible with older versions of TypeScript, which I think is nice, as several people have bumped into this.