### PR TITLE
Remove prefixes from MariaDB double-quoted strings

### DIFF
--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -270,10 +270,7 @@ export default class MariaDbFormatter extends Formatter {
       reservedKeywords: keywords,
       reservedFunctionNames: functions,
       // TODO: support _ char set prefixes such as _utf8, _latin1, _binary, _utf8mb4, etc.
-      stringTypes: [
-        { quote: "''", prefixes: ['B', 'X'] },
-        { quote: '""', prefixes: ['B', 'X'] },
-      ],
+      stringTypes: [{ quote: "''", prefixes: ['B', 'X'] }, '""'],
       identTypes: ['``'],
       identChars: { first: '$', rest: '$', allowFirstCharNumber: true },
       variableTypes: [

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -239,10 +239,7 @@ export default class MySqlFormatter extends Formatter {
       reservedKeywords: keywords,
       reservedFunctionNames: functions,
       // TODO: support _ char set prefixes such as _utf8, _latin1, _binary, _utf8mb4, etc.
-      stringTypes: [
-        { quote: "''", prefixes: ['B', 'N', 'X'] },
-        { quote: '""', prefixes: ['B', 'N', 'X'] },
-      ],
+      stringTypes: [{ quote: "''", prefixes: ['B', 'N', 'X'] }, '""'],
       identTypes: ['``'],
       identChars: { first: '$', rest: '$', allowFirstCharNumber: true },
       variableTypes: [

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -238,10 +238,7 @@ export default class SingleStoreDbFormatter extends Formatter {
       reservedKeywords: keywords,
       reservedFunctionNames: functions,
       // TODO: support _binary"some string" prefix
-      stringTypes: [
-        { quote: "''", prefixes: ['B', 'X'] },
-        { quote: '""', prefixes: ['B', 'X'] },
-      ],
+      stringTypes: [{ quote: "''", prefixes: ['B', 'X'] }, '""'],
       identTypes: ['``'],
       identChars: { first: '$', rest: '$', allowFirstCharNumber: true },
       variableTypes: [


### PR DESCRIPTION
Only the single-quoted versions of these are actually supported.

For all MariaDB-like databases: MariaDB, MySQL, SingleStoreDB

Also updated wiki docs with note that the missing double-quoted versions are intentional. (Some dialects, like Spark and BigQuery do support both single- and double-quoted strings with prefixes).