### PR TITLE
Reduce coupling between Tokenizer and TokenizerEngine

### DIFF
--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -3,9 +3,7 @@ import * as regex from 'src/lexer/regexFactory';
 import { ParamTypes, TokenizerOptions } from 'src/lexer/TokenizerOptions';
 import TokenizerEngine, { type TokenRule } from 'src/lexer/TokenizerEngine';
 import { escapeRegExp } from 'src/lexer/regexUtil';
-import { equalizeWhitespace } from 'src/utils';
-
-type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+import { equalizeWhitespace, Optional } from 'src/utils';
 
 type OptionalTokenRule = Optional<TokenRule, 'regex'>;
 

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -25,87 +25,119 @@ export default class Tokenizer {
   // the Tokenizer config options specified for each SQL dialect
   private buildDialectRules(cfg: TokenizerOptions): Partial<Record<TokenType, TokenRule>> {
     return this.validRules({
-      [TokenType.BLOCK_COMMENT]: { regex: /(\/\*[^]*?(?:\*\/|$))/uy },
+      [TokenType.BLOCK_COMMENT]: {
+        type: TokenType.BLOCK_COMMENT,
+        regex: /(\/\*[^]*?(?:\*\/|$))/uy,
+      },
       [TokenType.LINE_COMMENT]: {
+        type: TokenType.LINE_COMMENT,
         regex: regex.lineComment(cfg.lineCommentTypes ?? ['--']),
       },
-      [TokenType.QUOTED_IDENTIFIER]: { regex: regex.string(cfg.identTypes) },
+      [TokenType.QUOTED_IDENTIFIER]: {
+        type: TokenType.QUOTED_IDENTIFIER,
+        regex: regex.string(cfg.identTypes),
+      },
       [TokenType.NUMBER]: {
+        type: TokenType.NUMBER,
         regex:
           /(?:0x[0-9a-fA-F]+|0b[01]+|(?:-\s*)?[0-9]+(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+(?:\.[0-9]+)?)?)(?!\w)/uy,
       },
       [TokenType.CASE]: {
+        type: TokenType.CASE,
         regex: /CASE\b/iuy,
         text: toCanonical,
       },
       [TokenType.END]: {
+        type: TokenType.END,
         regex: /END\b/iuy,
         text: toCanonical,
       },
       [TokenType.BETWEEN]: {
+        type: TokenType.BETWEEN,
         regex: /BETWEEN\b/iuy,
         text: toCanonical,
       },
       [TokenType.LIMIT]: {
+        type: TokenType.LIMIT,
         regex: cfg.reservedCommands.includes('LIMIT') ? /LIMIT\b/iuy : undefined,
         text: toCanonical,
       },
       [TokenType.RESERVED_COMMAND]: {
+        type: TokenType.RESERVED_COMMAND,
         regex: regex.reservedWord(cfg.reservedCommands, cfg.identChars),
         text: toCanonical,
       },
       [TokenType.RESERVED_SELECT]: {
+        type: TokenType.RESERVED_SELECT,
         regex: regex.reservedWord(cfg.reservedSelect, cfg.identChars),
         text: toCanonical,
       },
       [TokenType.RESERVED_SET_OPERATION]: {
+        type: TokenType.RESERVED_SET_OPERATION,
         regex: regex.reservedWord(cfg.reservedSetOperations, cfg.identChars),
         text: toCanonical,
       },
       [TokenType.RESERVED_DEPENDENT_CLAUSE]: {
+        type: TokenType.RESERVED_DEPENDENT_CLAUSE,
         regex: regex.reservedWord(cfg.reservedDependentClauses, cfg.identChars),
         text: toCanonical,
       },
       [TokenType.RESERVED_JOIN]: {
+        type: TokenType.RESERVED_JOIN,
         regex: regex.reservedWord(cfg.reservedJoins, cfg.identChars),
         text: toCanonical,
       },
       [TokenType.RESERVED_PHRASE]: {
+        type: TokenType.RESERVED_PHRASE,
         regex: regex.reservedWord(cfg.reservedPhrases ?? [], cfg.identChars),
         text: toCanonical,
       },
       [TokenType.AND]: {
+        type: TokenType.AND,
         regex: /AND\b/iuy,
         text: toCanonical,
       },
       [TokenType.OR]: {
+        type: TokenType.OR,
         regex: /OR\b/iuy,
         text: toCanonical,
       },
       [TokenType.XOR]: {
+        type: TokenType.XOR,
         regex: cfg.supportsXor ? /XOR\b/iuy : undefined,
         text: toCanonical,
       },
       [TokenType.RESERVED_FUNCTION_NAME]: {
+        type: TokenType.RESERVED_FUNCTION_NAME,
         regex: regex.reservedWord(cfg.reservedFunctionNames, cfg.identChars),
         text: toCanonical,
       },
       [TokenType.RESERVED_KEYWORD]: {
+        type: TokenType.RESERVED_KEYWORD,
         regex: regex.reservedWord(cfg.reservedKeywords, cfg.identChars),
         text: toCanonical,
       },
       [TokenType.VARIABLE]: {
+        type: TokenType.VARIABLE,
         regex: cfg.variableTypes ? regex.variable(cfg.variableTypes) : undefined,
       },
-      [TokenType.STRING]: { regex: regex.string(cfg.stringTypes) },
+      [TokenType.STRING]: { type: TokenType.STRING, regex: regex.string(cfg.stringTypes) },
       [TokenType.IDENTIFIER]: {
+        type: TokenType.IDENTIFIER,
         regex: regex.identifier(cfg.identChars),
       },
-      [TokenType.DELIMITER]: { regex: /[;]/uy },
-      [TokenType.COMMA]: { regex: /[,]/y },
-      [TokenType.OPEN_PAREN]: { regex: regex.parenthesis('open', cfg.extraParens) },
-      [TokenType.CLOSE_PAREN]: { regex: regex.parenthesis('close', cfg.extraParens) },
+      [TokenType.DELIMITER]: { type: TokenType.DELIMITER, regex: /[;]/uy },
+      [TokenType.COMMA]: { type: TokenType.COMMA, regex: /[,]/y },
+      [TokenType.OPEN_PAREN]: {
+        type: TokenType.OPEN_PAREN,
+        regex: regex.parenthesis('open', cfg.extraParens),
+      },
+      [TokenType.CLOSE_PAREN]: {
+        type: TokenType.CLOSE_PAREN,
+        regex: regex.parenthesis('close', cfg.extraParens),
+      },
       [TokenType.OPERATOR]: {
+        type: TokenType.OPERATOR,
         regex: regex.operator('+-/%&|^><=.:$@#?~!', [
           '<>',
           '<=',
@@ -114,7 +146,7 @@ export default class Tokenizer {
           ...(cfg.operators ?? []),
         ]),
       },
-      [TokenType.ASTERISK]: { regex: /[*]/uy },
+      [TokenType.ASTERISK]: { type: TokenType.ASTERISK, regex: /[*]/uy },
     });
   }
 
@@ -138,6 +170,7 @@ export default class Tokenizer {
 
     return this.validRules({
       [TokenType.NAMED_PARAMETER]: {
+        type: TokenType.NAMED_PARAMETER,
         regex: regex.parameter(
           paramTypes.named,
           regex.identifierPattern(cfg.paramChars || cfg.identChars)
@@ -145,6 +178,7 @@ export default class Tokenizer {
         key: v => v.slice(1),
       },
       [TokenType.QUOTED_PARAMETER]: {
+        type: TokenType.QUOTED_PARAMETER,
         regex: regex.parameter(paramTypes.quoted, regex.stringPattern(cfg.identTypes)),
         key: v =>
           (({ tokenKey, quoteChar }) =>
@@ -154,10 +188,12 @@ export default class Tokenizer {
           }),
       },
       [TokenType.NUMBERED_PARAMETER]: {
+        type: TokenType.NUMBERED_PARAMETER,
         regex: regex.parameter(paramTypes.numbered, '[0-9]+'),
         key: v => v.slice(1),
       },
       [TokenType.POSITIONAL_PARAMETER]: {
+        type: TokenType.POSITIONAL_PARAMETER,
         regex: paramTypes.positional ? /[?]/y : undefined,
       },
     });

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -36,63 +36,63 @@ export default class Tokenizer {
       },
       [TokenType.CASE]: {
         regex: /CASE\b/iuy,
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.END]: {
         regex: /END\b/iuy,
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.BETWEEN]: {
         regex: /BETWEEN\b/iuy,
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.LIMIT]: {
         regex: cfg.reservedCommands.includes('LIMIT') ? /LIMIT\b/iuy : undefined,
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_COMMAND]: {
         regex: regex.reservedWord(cfg.reservedCommands, cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_SELECT]: {
         regex: regex.reservedWord(cfg.reservedSelect, cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_SET_OPERATION]: {
         regex: regex.reservedWord(cfg.reservedSetOperations, cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_DEPENDENT_CLAUSE]: {
         regex: regex.reservedWord(cfg.reservedDependentClauses, cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_JOIN]: {
         regex: regex.reservedWord(cfg.reservedJoins, cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_PHRASE]: {
         regex: regex.reservedWord(cfg.reservedPhrases ?? [], cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.AND]: {
         regex: /AND\b/iuy,
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.OR]: {
         regex: /OR\b/iuy,
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.XOR]: {
         regex: cfg.supportsXor ? /XOR\b/iuy : undefined,
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_FUNCTION_NAME]: {
         regex: regex.reservedWord(cfg.reservedFunctionNames, cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.RESERVED_KEYWORD]: {
         regex: regex.reservedWord(cfg.reservedKeywords, cfg.identChars),
-        value: toCanonical,
+        text: toCanonical,
       },
       [TokenType.VARIABLE]: {
         regex: cfg.variableTypes ? regex.variable(cfg.variableTypes) : undefined,

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -5,138 +5,152 @@ import TokenizerEngine, { type TokenRule } from 'src/lexer/TokenizerEngine';
 import { escapeRegExp } from 'src/lexer/regexUtil';
 import { equalizeWhitespace } from 'src/utils';
 
+type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+
+type OptionalTokenRule = Optional<TokenRule, 'regex'>;
+
 export default class Tokenizer {
-  private dialectRules: Partial<Record<TokenType, TokenRule>>;
+  private rulesBeforeParams: TokenRule[];
+  private rulesAfterParams: TokenRule[];
 
   constructor(private cfg: TokenizerOptions) {
-    this.dialectRules = this.buildDialectRules(cfg);
+    this.rulesBeforeParams = this.buildRulesBeforeParams(cfg);
+    this.rulesAfterParams = this.buildRulesAfterParams(cfg);
   }
 
   public tokenize(input: string, paramTypesOverrides: ParamTypes): Token[] {
-    const rules = {
-      ...this.dialectRules,
+    const rules = [
+      ...this.rulesBeforeParams,
       ...this.buildParamRules(this.cfg, paramTypesOverrides),
-    };
+      ...this.rulesAfterParams,
+    ];
     const tokens = new TokenizerEngine(rules).tokenize(input);
     return this.cfg.postProcess ? this.cfg.postProcess(tokens) : tokens;
   }
 
   // These rules can be cached as they only depend on
   // the Tokenizer config options specified for each SQL dialect
-  private buildDialectRules(cfg: TokenizerOptions): Partial<Record<TokenType, TokenRule>> {
-    return this.validRules({
-      [TokenType.BLOCK_COMMENT]: {
+  private buildRulesBeforeParams(cfg: TokenizerOptions): TokenRule[] {
+    return this.validRules([
+      {
         type: TokenType.BLOCK_COMMENT,
         regex: /(\/\*[^]*?(?:\*\/|$))/uy,
       },
-      [TokenType.LINE_COMMENT]: {
+      {
         type: TokenType.LINE_COMMENT,
         regex: regex.lineComment(cfg.lineCommentTypes ?? ['--']),
       },
-      [TokenType.QUOTED_IDENTIFIER]: {
+      {
         type: TokenType.QUOTED_IDENTIFIER,
         regex: regex.string(cfg.identTypes),
       },
-      [TokenType.NUMBER]: {
+      {
         type: TokenType.NUMBER,
         regex:
           /(?:0x[0-9a-fA-F]+|0b[01]+|(?:-\s*)?[0-9]+(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+(?:\.[0-9]+)?)?)(?!\w)/uy,
       },
-      [TokenType.CASE]: {
+      {
         type: TokenType.CASE,
         regex: /CASE\b/iuy,
         text: toCanonical,
       },
-      [TokenType.END]: {
+      {
         type: TokenType.END,
         regex: /END\b/iuy,
         text: toCanonical,
       },
-      [TokenType.BETWEEN]: {
+      {
         type: TokenType.BETWEEN,
         regex: /BETWEEN\b/iuy,
         text: toCanonical,
       },
-      [TokenType.LIMIT]: {
+      {
         type: TokenType.LIMIT,
         regex: cfg.reservedCommands.includes('LIMIT') ? /LIMIT\b/iuy : undefined,
         text: toCanonical,
       },
-      [TokenType.RESERVED_COMMAND]: {
+      {
         type: TokenType.RESERVED_COMMAND,
         regex: regex.reservedWord(cfg.reservedCommands, cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.RESERVED_SELECT]: {
+      {
         type: TokenType.RESERVED_SELECT,
         regex: regex.reservedWord(cfg.reservedSelect, cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.RESERVED_SET_OPERATION]: {
+      {
         type: TokenType.RESERVED_SET_OPERATION,
         regex: regex.reservedWord(cfg.reservedSetOperations, cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.RESERVED_DEPENDENT_CLAUSE]: {
+      {
         type: TokenType.RESERVED_DEPENDENT_CLAUSE,
         regex: regex.reservedWord(cfg.reservedDependentClauses, cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.RESERVED_JOIN]: {
+      {
         type: TokenType.RESERVED_JOIN,
         regex: regex.reservedWord(cfg.reservedJoins, cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.RESERVED_PHRASE]: {
+      {
         type: TokenType.RESERVED_PHRASE,
         regex: regex.reservedWord(cfg.reservedPhrases ?? [], cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.AND]: {
+      {
         type: TokenType.AND,
         regex: /AND\b/iuy,
         text: toCanonical,
       },
-      [TokenType.OR]: {
+      {
         type: TokenType.OR,
         regex: /OR\b/iuy,
         text: toCanonical,
       },
-      [TokenType.XOR]: {
+      {
         type: TokenType.XOR,
         regex: cfg.supportsXor ? /XOR\b/iuy : undefined,
         text: toCanonical,
       },
-      [TokenType.RESERVED_FUNCTION_NAME]: {
+      {
         type: TokenType.RESERVED_FUNCTION_NAME,
         regex: regex.reservedWord(cfg.reservedFunctionNames, cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.RESERVED_KEYWORD]: {
+      {
         type: TokenType.RESERVED_KEYWORD,
         regex: regex.reservedWord(cfg.reservedKeywords, cfg.identChars),
         text: toCanonical,
       },
-      [TokenType.VARIABLE]: {
+    ]);
+  }
+
+  // These rules can also be cached as they only depend on
+  // the Tokenizer config options specified for each SQL dialect
+  private buildRulesAfterParams(cfg: TokenizerOptions): TokenRule[] {
+    return this.validRules([
+      {
         type: TokenType.VARIABLE,
         regex: cfg.variableTypes ? regex.variable(cfg.variableTypes) : undefined,
       },
-      [TokenType.STRING]: { type: TokenType.STRING, regex: regex.string(cfg.stringTypes) },
-      [TokenType.IDENTIFIER]: {
+      { type: TokenType.STRING, regex: regex.string(cfg.stringTypes) },
+      {
         type: TokenType.IDENTIFIER,
         regex: regex.identifier(cfg.identChars),
       },
-      [TokenType.DELIMITER]: { type: TokenType.DELIMITER, regex: /[;]/uy },
-      [TokenType.COMMA]: { type: TokenType.COMMA, regex: /[,]/y },
-      [TokenType.OPEN_PAREN]: {
+      { type: TokenType.DELIMITER, regex: /[;]/uy },
+      { type: TokenType.COMMA, regex: /[,]/y },
+      {
         type: TokenType.OPEN_PAREN,
         regex: regex.parenthesis('open', cfg.extraParens),
       },
-      [TokenType.CLOSE_PAREN]: {
+      {
         type: TokenType.CLOSE_PAREN,
         regex: regex.parenthesis('close', cfg.extraParens),
       },
-      [TokenType.OPERATOR]: {
+      {
         type: TokenType.OPERATOR,
         regex: regex.operator('+-/%&|^><=.:$@#?~!', [
           '<>',
@@ -146,16 +160,13 @@ export default class Tokenizer {
           ...(cfg.operators ?? []),
         ]),
       },
-      [TokenType.ASTERISK]: { type: TokenType.ASTERISK, regex: /[*]/uy },
-    });
+      { type: TokenType.ASTERISK, regex: /[*]/uy },
+    ]);
   }
 
   // These rules can't be blindly cached as the paramTypesOverrides object
   // can differ on each invocation of the format() function.
-  private buildParamRules(
-    cfg: TokenizerOptions,
-    paramTypesOverrides: ParamTypes
-  ): Partial<Record<TokenType, TokenRule>> {
+  private buildParamRules(cfg: TokenizerOptions, paramTypesOverrides: ParamTypes): TokenRule[] {
     // Each dialect has its own default parameter types (if any),
     // but these can be overriden by the user of the library.
     const paramTypes = {
@@ -168,8 +179,8 @@ export default class Tokenizer {
           : cfg.paramTypes?.positional,
     };
 
-    return this.validRules({
-      [TokenType.NAMED_PARAMETER]: {
+    return this.validRules([
+      {
         type: TokenType.NAMED_PARAMETER,
         regex: regex.parameter(
           paramTypes.named,
@@ -177,7 +188,7 @@ export default class Tokenizer {
         ),
         key: v => v.slice(1),
       },
-      [TokenType.QUOTED_PARAMETER]: {
+      {
         type: TokenType.QUOTED_PARAMETER,
         regex: regex.parameter(paramTypes.quoted, regex.stringPattern(cfg.identTypes)),
         key: v =>
@@ -187,23 +198,21 @@ export default class Tokenizer {
             quoteChar: v.slice(-1),
           }),
       },
-      [TokenType.NUMBERED_PARAMETER]: {
+      {
         type: TokenType.NUMBERED_PARAMETER,
         regex: regex.parameter(paramTypes.numbered, '[0-9]+'),
         key: v => v.slice(1),
       },
-      [TokenType.POSITIONAL_PARAMETER]: {
+      {
         type: TokenType.POSITIONAL_PARAMETER,
         regex: paramTypes.positional ? /[?]/y : undefined,
       },
-    });
+    ]);
   }
 
   // filters out rules for token types whose regex is undefined
-  private validRules(
-    rules: Partial<Record<TokenType, TokenRule | { regex: undefined }>>
-  ): Partial<Record<TokenType, TokenRule>> {
-    return Object.fromEntries(Object.entries(rules).filter(([_, rule]) => rule.regex));
+  private validRules(rules: OptionalTokenRule[]): TokenRule[] {
+    return rules.filter((rule): rule is TokenRule => Boolean(rule.regex));
   }
 }
 

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -67,7 +67,21 @@ export default class TokenizerEngine {
       this.matchToken(TokenType.LINE_COMMENT) ||
       this.matchToken(TokenType.QUOTED_IDENTIFIER) ||
       this.matchToken(TokenType.NUMBER) ||
-      this.matchReservedWordToken() ||
+      this.matchToken(TokenType.CASE) ||
+      this.matchToken(TokenType.END) ||
+      this.matchToken(TokenType.BETWEEN) ||
+      this.matchToken(TokenType.LIMIT) ||
+      this.matchToken(TokenType.RESERVED_COMMAND) ||
+      this.matchToken(TokenType.RESERVED_SELECT) ||
+      this.matchToken(TokenType.RESERVED_SET_OPERATION) ||
+      this.matchToken(TokenType.RESERVED_DEPENDENT_CLAUSE) ||
+      this.matchToken(TokenType.RESERVED_JOIN) ||
+      this.matchToken(TokenType.RESERVED_PHRASE) ||
+      this.matchToken(TokenType.AND) ||
+      this.matchToken(TokenType.OR) ||
+      this.matchToken(TokenType.XOR) ||
+      this.matchToken(TokenType.RESERVED_FUNCTION_NAME) ||
+      this.matchToken(TokenType.RESERVED_KEYWORD) ||
       this.matchPlaceholderToken(TokenType.NAMED_PARAMETER) ||
       this.matchPlaceholderToken(TokenType.QUOTED_PARAMETER) ||
       this.matchPlaceholderToken(TokenType.NUMBERED_PARAMETER) ||
@@ -96,27 +110,6 @@ export default class TokenizerEngine {
       }
     }
     return undefined;
-  }
-
-  private matchReservedWordToken(): Token | undefined {
-    // prioritised list of Reserved token types
-    return (
-      this.matchToken(TokenType.CASE) ||
-      this.matchToken(TokenType.END) ||
-      this.matchToken(TokenType.BETWEEN) ||
-      this.matchToken(TokenType.LIMIT) ||
-      this.matchToken(TokenType.RESERVED_COMMAND) ||
-      this.matchToken(TokenType.RESERVED_SELECT) ||
-      this.matchToken(TokenType.RESERVED_SET_OPERATION) ||
-      this.matchToken(TokenType.RESERVED_DEPENDENT_CLAUSE) ||
-      this.matchToken(TokenType.RESERVED_JOIN) ||
-      this.matchToken(TokenType.RESERVED_PHRASE) ||
-      this.matchToken(TokenType.AND) ||
-      this.matchToken(TokenType.OR) ||
-      this.matchToken(TokenType.XOR) ||
-      this.matchToken(TokenType.RESERVED_FUNCTION_NAME) ||
-      this.matchToken(TokenType.RESERVED_KEYWORD)
-    );
   }
 
   // Shorthand for `match` that looks up regex from rules

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -4,7 +4,7 @@ import { WHITESPACE_REGEX } from './regexUtil';
 export interface TokenRule {
   regex: RegExp;
   key?: (token: string) => string;
-  value?: (token: string) => string;
+  text?: (token: string) => string;
 }
 
 export default class TokenizerEngine {
@@ -117,7 +117,7 @@ export default class TokenizerEngine {
       const token: Token = {
         type,
         raw: matchedText,
-        text: rule.value ? rule.value(matchedText) : matchedText,
+        text: rule.text ? rule.text(matchedText) : matchedText,
         start: this.index,
         end: this.index + matchedText.length,
       };

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -127,14 +127,14 @@ export default class TokenizerEngine {
     regex.lastIndex = this.index;
     const matches = regex.exec(this.input);
     if (matches) {
-      const matchedToken = matches[0];
+      const matchedText = matches[0];
 
       const token: Token = {
         type,
-        raw: matchedToken,
-        text: transform ? transform(matchedToken) : matchedToken,
+        raw: matchedText,
+        text: transform ? transform(matchedText) : matchedText,
         start: this.index,
-        end: this.index + matchedToken.length,
+        end: this.index + matchedText.length,
       };
 
       if (transformKey) {
@@ -142,7 +142,7 @@ export default class TokenizerEngine {
       }
 
       // Advance current position by matched token length
-      this.index += matchedToken.length;
+      this.index += matchedText.length;
       return token;
     }
     return undefined;

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -10,15 +10,10 @@ export interface TokenRule {
 }
 
 export default class TokenizerEngine {
-  private rules: Partial<Record<TokenType, TokenRule>>;
-
   private input = ''; // The input SQL string to process
-
   private index = 0; // Current position in string
 
-  constructor(rules: Partial<Record<TokenType, TokenRule>>) {
-    this.rules = rules;
-  }
+  constructor(private rules: TokenRule[]) {}
 
   /**
    * Takes a SQL string and breaks it into tokens.
@@ -64,52 +59,16 @@ export default class TokenizerEngine {
   }
 
   private getNextToken(): Token | undefined {
-    return (
-      this.matchToken(TokenType.BLOCK_COMMENT) ||
-      this.matchToken(TokenType.LINE_COMMENT) ||
-      this.matchToken(TokenType.QUOTED_IDENTIFIER) ||
-      this.matchToken(TokenType.NUMBER) ||
-      this.matchToken(TokenType.CASE) ||
-      this.matchToken(TokenType.END) ||
-      this.matchToken(TokenType.BETWEEN) ||
-      this.matchToken(TokenType.LIMIT) ||
-      this.matchToken(TokenType.RESERVED_COMMAND) ||
-      this.matchToken(TokenType.RESERVED_SELECT) ||
-      this.matchToken(TokenType.RESERVED_SET_OPERATION) ||
-      this.matchToken(TokenType.RESERVED_DEPENDENT_CLAUSE) ||
-      this.matchToken(TokenType.RESERVED_JOIN) ||
-      this.matchToken(TokenType.RESERVED_PHRASE) ||
-      this.matchToken(TokenType.AND) ||
-      this.matchToken(TokenType.OR) ||
-      this.matchToken(TokenType.XOR) ||
-      this.matchToken(TokenType.RESERVED_FUNCTION_NAME) ||
-      this.matchToken(TokenType.RESERVED_KEYWORD) ||
-      this.matchToken(TokenType.NAMED_PARAMETER) ||
-      this.matchToken(TokenType.QUOTED_PARAMETER) ||
-      this.matchToken(TokenType.NUMBERED_PARAMETER) ||
-      this.matchToken(TokenType.POSITIONAL_PARAMETER) ||
-      this.matchToken(TokenType.VARIABLE) ||
-      this.matchToken(TokenType.STRING) ||
-      this.matchToken(TokenType.IDENTIFIER) ||
-      this.matchToken(TokenType.DELIMITER) ||
-      this.matchToken(TokenType.COMMA) ||
-      this.matchToken(TokenType.OPEN_PAREN) ||
-      this.matchToken(TokenType.CLOSE_PAREN) ||
-      this.matchToken(TokenType.OPERATOR) ||
-      this.matchToken(TokenType.ASTERISK)
-    );
-  }
-
-  // Shorthand for `match` that looks up regex from rules
-  private matchToken(tokenType: TokenType): Token | undefined {
-    const rule = this.rules[tokenType];
-    if (!rule) {
-      return undefined;
+    for (const rule of this.rules) {
+      const token = this.match(rule);
+      if (token) {
+        return token;
+      }
     }
-    return this.match(rule);
+    return undefined;
   }
 
-  // Attempts to match RegExp at current position in input
+  // Attempts to match token rule regex at current position in input
   private match(rule: TokenRule): Token | undefined {
     rule.regex.lastIndex = this.index;
     const matches = rule.regex.exec(this.input);

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -2,6 +2,7 @@ import { Token, TokenType } from 'src/lexer/token';
 import { WHITESPACE_REGEX } from './regexUtil';
 
 export interface TokenRule {
+  type: TokenType;
   regex: RegExp;
   // Called with the raw string that was matched
   text?: (rawText: string) => string;
@@ -105,18 +106,18 @@ export default class TokenizerEngine {
     if (!rule) {
       return undefined;
     }
-    return this.match(tokenType, rule);
+    return this.match(rule);
   }
 
   // Attempts to match RegExp at current position in input
-  private match(type: TokenType, rule: TokenRule): Token | undefined {
+  private match(rule: TokenRule): Token | undefined {
     rule.regex.lastIndex = this.index;
     const matches = rule.regex.exec(this.input);
     if (matches) {
       const matchedText = matches[0];
 
       const token: Token = {
-        type,
+        type: rule.type,
         raw: matchedText,
         text: rule.text ? rule.text(matchedText) : matchedText,
         start: this.index,

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -104,41 +104,26 @@ export default class TokenizerEngine {
     if (!rule) {
       return undefined;
     }
-    return this.match({
-      type: tokenType,
-      regex: rule.regex,
-      transform: rule.value,
-      transformKey: rule.key,
-    });
+    return this.match(tokenType, rule);
   }
 
   // Attempts to match RegExp at current position in input
-  private match({
-    type,
-    regex,
-    transform,
-    transformKey,
-  }: {
-    type: TokenType;
-    regex: RegExp;
-    transform?: (s: string) => string;
-    transformKey?: (s: string) => string;
-  }): Token | undefined {
-    regex.lastIndex = this.index;
-    const matches = regex.exec(this.input);
+  private match(type: TokenType, rule: TokenRule): Token | undefined {
+    rule.regex.lastIndex = this.index;
+    const matches = rule.regex.exec(this.input);
     if (matches) {
       const matchedText = matches[0];
 
       const token: Token = {
         type,
         raw: matchedText,
-        text: transform ? transform(matchedText) : matchedText,
+        text: rule.value ? rule.value(matchedText) : matchedText,
         start: this.index,
         end: this.index + matchedText.length,
       };
 
-      if (transformKey) {
-        token.key = transformKey(token.text);
+      if (rule.key) {
+        token.key = rule.key(token.text);
       }
 
       // Advance current position by matched token length

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -38,7 +38,7 @@ export default class TokenizerEngine {
 
       if (this.index < this.input.length) {
         // Get the next token and the token type
-        token = this.getNextToken(token);
+        token = this.getNextToken();
         if (!token) {
           throw new Error(`Parse error: Unexpected "${input.slice(this.index, 100)}"`);
         }
@@ -61,13 +61,13 @@ export default class TokenizerEngine {
     return undefined;
   }
 
-  private getNextToken(previousToken?: Token): Token | undefined {
+  private getNextToken(): Token | undefined {
     return (
       this.matchToken(TokenType.BLOCK_COMMENT) ||
       this.matchToken(TokenType.LINE_COMMENT) ||
       this.matchToken(TokenType.QUOTED_IDENTIFIER) ||
       this.matchToken(TokenType.NUMBER) ||
-      this.matchReservedWordToken(previousToken) ||
+      this.matchReservedWordToken() ||
       this.matchPlaceholderToken(TokenType.NAMED_PARAMETER) ||
       this.matchPlaceholderToken(TokenType.QUOTED_PARAMETER) ||
       this.matchPlaceholderToken(TokenType.NUMBERED_PARAMETER) ||
@@ -98,13 +98,7 @@ export default class TokenizerEngine {
     return undefined;
   }
 
-  private matchReservedWordToken(previousToken?: Token): Token | undefined {
-    // A reserved word cannot be preceded by a '.'
-    // this makes it so in "mytable.from", "from" is not considered a reserved word
-    if (previousToken?.text === '.') {
-      return undefined;
-    }
-
+  private matchReservedWordToken(): Token | undefined {
     // prioritised list of Reserved token types
     return (
       this.matchToken(TokenType.CASE) ||

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -3,8 +3,9 @@ import { WHITESPACE_REGEX } from './regexUtil';
 
 export interface TokenRule {
   regex: RegExp;
-  key?: (token: string) => string;
-  text?: (token: string) => string;
+  // Called with the raw string that was matched
+  text?: (rawText: string) => string;
+  key?: (rawText: string) => string;
 }
 
 export default class TokenizerEngine {
@@ -123,7 +124,7 @@ export default class TokenizerEngine {
       };
 
       if (rule.key) {
-        token.key = rule.key(token.text);
+        token.key = rule.key(matchedText);
       }
 
       // Advance current position by matched token length

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -129,7 +129,7 @@ export default class TokenizerEngine {
     if (matches) {
       const matchedToken = matches[0];
 
-      const outToken: Token = {
+      const token: Token = {
         type,
         raw: matchedToken,
         text: transform ? transform(matchedToken) : matchedToken,
@@ -138,12 +138,12 @@ export default class TokenizerEngine {
       };
 
       if (transformKey) {
-        outToken.key = transformKey(outToken.text);
+        token.key = transformKey(token.text);
       }
 
       // Advance current position by matched token length
       this.index += matchedToken.length;
-      return outToken;
+      return token;
     }
     return undefined;
   }

--- a/src/lexer/disambiguateTokens.ts
+++ b/src/lexer/disambiguateTokens.ts
@@ -18,25 +18,25 @@ export function disambiguateTokens(tokens: Token[]): Token[] {
     if (isReserved(token.type)) {
       const prevToken = tokens[i - 1];
       if (prevToken && prevToken.text === '.') {
-        return { ...token, type: TokenType.IDENTIFIER, text: token.raw };
+        token = { ...token, type: TokenType.IDENTIFIER, text: token.raw };
       }
     }
     if (token.type === TokenType.RESERVED_FUNCTION_NAME) {
       const nextToken = tokens[i + 1];
       if (!nextToken || !isOpenParen(nextToken)) {
-        return { ...token, type: TokenType.RESERVED_KEYWORD };
+        token = { ...token, type: TokenType.RESERVED_KEYWORD };
       }
     }
     if (token.type === TokenType.IDENTIFIER) {
       const nextToken = tokens[i + 1];
       if (nextToken && isOpenBracket(nextToken)) {
-        return { ...token, type: TokenType.ARRAY_IDENTIFIER };
+        token = { ...token, type: TokenType.ARRAY_IDENTIFIER };
       }
     }
     if (token.type === TokenType.RESERVED_KEYWORD) {
       const nextToken = tokens[i + 1];
       if (nextToken && isOpenBracket(nextToken)) {
-        return { ...token, type: TokenType.ARRAY_KEYWORD };
+        token = { ...token, type: TokenType.ARRAY_KEYWORD };
       }
     }
     return token;

--- a/src/lexer/disambiguateTokens.ts
+++ b/src/lexer/disambiguateTokens.ts
@@ -1,6 +1,8 @@
-import { Token, TokenType } from 'src/lexer/token';
+import { isReserved, Token, TokenType } from 'src/lexer/token';
 
 /**
+ * Ensures that no keyword token (RESERVED_*) is preceded by dot (.).
+ *
  * Ensures that all RESERVED_FUNCTION_NAME tokens are followed by "(".
  * If they're not, converts the token to RESERVED_KEYWORD.
  *
@@ -13,6 +15,12 @@ import { Token, TokenType } from 'src/lexer/token';
  */
 export function disambiguateTokens(tokens: Token[]): Token[] {
   return tokens.map((token, i) => {
+    if (isReserved(token.type)) {
+      const prevToken = tokens[i - 1];
+      if (prevToken && prevToken.text === '.') {
+        return { ...token, type: TokenType.IDENTIFIER, text: token.raw };
+      }
+    }
     if (token.type === TokenType.RESERVED_FUNCTION_NAME) {
       const nextToken = tokens[i + 1];
       if (!nextToken || !isOpenParen(nextToken)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,3 +27,12 @@ export const sum = (arr: number[]): number => {
 // Used for flattening keyword lists
 export const flatKeywordList = (obj: Record<string, string[]>): string[] =>
   dedupe(Object.values(obj).flat());
+
+// Given a type and a field name, returns a type where this field is optional
+//
+// For example, these two type definitions are equivalent:
+//
+//   type Foo = Optional<{ foo: string, bar: number }, 'foo'>;
+//   type Foo = { foo?: string, bar: number };
+//
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/test/features/arrayAndMapAccessors.ts
+++ b/test/features/arrayAndMapAccessors.ts
@@ -22,4 +22,12 @@ export default function supportsArrayAndMapAccessors(format: FormatFn) {
         yota['foo.bar-baz'];
     `);
   });
+
+  it('supports namespaced array identifiers', () => {
+    const result = format(`SELECT foo.coalesce['blah'];`);
+    expect(result).toBe(dedent`
+      SELECT
+        foo.coalesce['blah'];
+    `);
+  });
 }


### PR DESCRIPTION
`TokenizerEngine` now no more has knowledge of individual token types, eliminating the need to update both `Tokenizer` and `TokenizerEngine` each time we need a new token type.

`TokenizerEngine` now takes and array of `TokenRule` objects as input configuration, the order of which also defines the order of tokenization. (Instead of taking a map of `TokenType-TokenRule` pairs and looking up rules by type.)

To make this change possible, I also eliminated all token-type specific logic from the engine:

- The `key` field transform can now be applied to any token type, not only to `*_PARAMETER` tokens (though we still use it only for the latter).
- The no-keyword-can-come-after-dot logic has been moved into `disambiguateTokens()` function, which already deals with several similar sorts of transformations of the tokens list.