### PR TITLE
Add PropertyAccessNode

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -23,6 +23,7 @@ import {
   BlockCommentNode,
   CommaNode,
   KeywordNode,
+  PropertyAccessNode,
 } from 'src/parser/ast';
 
 import InlineBlock from './InlineBlock';
@@ -70,6 +71,8 @@ export default class ExpressionFormatter {
         return this.formatFunctionCall(node);
       case NodeType.array_subscript:
         return this.formatArraySubscript(node);
+      case NodeType.property_access:
+        return this.formatPropertyAccess(node);
       case NodeType.parenthesis:
         return this.formatParenthesis(node);
       case NodeType.between_predicate:
@@ -109,6 +112,12 @@ export default class ExpressionFormatter {
   private formatArraySubscript({ array, parenthesis }: ArraySubscriptNode) {
     this.layout.add(array.type === NodeType.keyword ? this.showKw(array) : array.text);
     this.formatParenthesis(parenthesis);
+  }
+
+  private formatPropertyAccess({ object, property }: PropertyAccessNode) {
+    this.formatNode(object);
+    this.layout.add(WS.NO_SPACE, '.');
+    this.formatNode(property);
   }
 
   private formatParenthesis(node: ParenthesisNode) {
@@ -207,7 +216,7 @@ export default class ExpressionFormatter {
     if (text === ':') {
       this.layout.add(WS.NO_SPACE, text, WS.SPACE);
       return;
-    } else if (text === '.' || text === '::') {
+    } else if (text === '::') {
       this.layout.add(WS.NO_SPACE, text);
       return;
     }

--- a/src/formatter/InlineBlock.ts
+++ b/src/formatter/InlineBlock.ts
@@ -41,6 +41,10 @@ export default class InlineBlock {
         case NodeType.array_subscript:
           length += node.array.text.length + this.inlineParenthesisWidth(node.parenthesis);
           break;
+        case NodeType.property_access:
+          // +1 for the separating dot
+          length += this.inlineWidth([node.object]) + 1 + this.inlineWidth([node.property]);
+          break;
         case NodeType.parenthesis:
           length += this.inlineParenthesisWidth(node);
           break;

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -152,7 +152,7 @@ export default class Tokenizer {
       },
       {
         type: TokenType.OPERATOR,
-        regex: regex.operator('+-/%&|^><=.:$@#?~!', [
+        regex: regex.operator('-+/%&|^><=:$@#?~!', [
           '<>',
           '<=',
           '>=',
@@ -161,6 +161,7 @@ export default class Tokenizer {
         ]),
       },
       { type: TokenType.ASTERISK, regex: /[*]/uy },
+      { type: TokenType.DOT, regex: /[.]/uy },
     ]);
   }
 

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -24,6 +24,7 @@ export enum TokenType {
   OPERATOR = 'OPERATOR',
   COMMA = 'COMMA',
   ASTERISK = 'ASTERISK', // *
+  DOT = 'DOT', // .
   OPEN_PAREN = 'OPEN_PAREN',
   CLOSE_PAREN = 'CLOSE_PAREN',
   LINE_COMMENT = 'LINE_COMMENT',

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -6,6 +6,7 @@ export enum NodeType {
   set_operation = 'set_operation',
   function_call = 'function_call',
   array_subscript = 'array_subscript',
+  property_access = 'property_access',
   parenthesis = 'parenthesis',
   between_predicate = 'between_predicate',
   limit_clause = 'limit_clause',
@@ -86,6 +87,12 @@ export type LiteralNode = {
   text: string;
 };
 
+export type PropertyAccessNode = {
+  type: NodeType.property_access;
+  object: AstNode;
+  property: IdentifierNode;
+};
+
 export type IdentifierNode = {
   type: NodeType.identifier;
   text: string;
@@ -129,6 +136,7 @@ export type AstNode =
   | SetOperationNode
   | FunctionCallNode
   | ArraySubscriptNode
+  | PropertyAccessNode
   | ParenthesisNode
   | BetweenPredicateNode
   | LimitClauseNode

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -106,11 +106,11 @@ set_operation -> %RESERVED_SET_OPERATION expression:* {%
   })
 %}
 
-expression -> ( simple_expression | asterisk | comma ) {% unwrap %}
+expression -> ( simple_expression | between_predicate | asterisk | comma ) {% unwrap %}
 
-asteriskless_expression -> ( simple_expression | comma ) {% unwrap %}
+asteriskless_expression -> ( simple_expression | between_predicate | comma ) {% unwrap %}
 
-commaless_expression -> ( simple_expression | asterisk ) {% unwrap %}
+commaless_expression -> ( simple_expression | between_predicate | asterisk ) {% unwrap %}
 
 simple_expression ->
   ( array_subscript
@@ -119,7 +119,6 @@ simple_expression ->
   | parenthesis
   | curly_braces
   | square_brackets
-  | between_predicate
   | expression_token ) {% unwrap %}
 
 array_subscript -> %ARRAY_IDENTIFIER square_brackets {%

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -115,6 +115,7 @@ commaless_expression -> ( simple_expression | asterisk ) {% unwrap %}
 simple_expression ->
   ( array_subscript
   | function_call
+  | property_access
   | parenthesis
   | curly_braces
   | square_brackets
@@ -169,6 +170,20 @@ square_brackets -> "[" expression:* "]" {%
     openParen: "[",
     closeParen: "]",
   })
+%}
+
+property_access -> simple_expression %DOT (identifier | array_subscript) {%
+  // Allowing property to be <array_subscript> is currently a hack.
+  // A better way would be to allow <property_access> on the left side of array_subscript,
+  // but we currently can't do that because of another hack that requires
+  // %ARRAY_IDENTIFIER on the left side of <array_subscript>.
+  ([object, dot, [property]]) => {
+    return {
+      type: NodeType.property_access,
+      object,
+      property,
+    };
+  }
 %}
 
 between_predicate -> %BETWEEN commaless_expression %AND commaless_expression {%

--- a/test/features/between.ts
+++ b/test/features/between.ts
@@ -4,4 +4,8 @@ export default function supportsBetween(format: FormatFn) {
   it('formats BETWEEN _ AND _ on single line', () => {
     expect(format('foo BETWEEN bar AND baz')).toBe('foo BETWEEN bar AND baz');
   });
+
+  it('supports qualified.names as BETWEEN expression values', () => {
+    expect(format('foo BETWEEN t.bar AND t.baz')).toBe('foo BETWEEN t.bar AND t.baz');
+  });
 }

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -78,4 +78,8 @@ describe('Parser', () => {
   it('parses square brackets', () => {
     expect(parse('SELECT [1, 2, 3];')).toMatchSnapshot();
   });
+
+  it('parses qualified.identifier.sequence', () => {
+    expect(parse('SELECT foo.bar.baz;')).toMatchSnapshot();
+  });
 });

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -442,6 +442,46 @@ Array [
 ]
 `;
 
+exports[`Parser parses qualified.identifier.sequence 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "object": Object {
+              "object": Object {
+                "text": "foo",
+                "type": "identifier",
+              },
+              "property": Object {
+                "text": "bar",
+                "type": "identifier",
+              },
+              "type": "property_access",
+            },
+            "property": Object {
+              "text": "baz",
+              "type": "identifier",
+            },
+            "type": "property_access",
+          },
+        ],
+        "name": Object {
+          "raw": "SELECT",
+          "text": "SELECT",
+          "tokenType": "RESERVED_SELECT",
+          "type": "keyword",
+        },
+        "type": "clause",
+      },
+    ],
+    "hasSemicolon": true,
+    "type": "statement",
+  },
+]
+`;
+
 exports[`Parser parses set operations 1`] = `
 Array [
   Object {


### PR DESCRIPTION
Replaced plain `"."` operator with `PropertyAccessNode`.

This solves the immediate problem of parsing `BETWEEN t.foo AND t.bar`, as `t.bar` is now considered a single expression (v/s previously being considered 3 separate expressions, which the BETWEEN-predicate didn't allow for).

It is a step in the right direction, but here the limits of our current approach are really starting to show. Like when one would write `BETWEEN 5+5 AND 20` this would still fail to parse, although `BETWEEN (5+5) AND 20` parses just fine.

Fixes #423