### PR TITLE
Fix PropertyAccessorNode.property type

### DIFF
--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -90,7 +90,7 @@ export type LiteralNode = {
 export type PropertyAccessNode = {
   type: NodeType.property_access;
   object: AstNode;
-  property: IdentifierNode;
+  property: IdentifierNode | ArraySubscriptNode | AllColumnsAsteriskNode;
 };
 
 export type IdentifierNode = {


### PR DESCRIPTION
Discovered this while working with adding location info.

Just a straightforward fix.