### PR TITLE
Attach comments to AST nodes

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -103,9 +103,11 @@ export default class ExpressionFormatter {
     }
   }
 
-  private formatFunctionCall(node: FunctionCallNode) {
-    this.layout.add(this.showKw(node.name));
-    this.formatParenthesis(node.parenthesis);
+  private formatFunctionCall({ name, parenthesis }: FunctionCallNode) {
+    this.formatComments(name.leadingComments);
+    this.layout.add(this.showKw(name));
+    this.formatComments(name.trailingComments);
+    this.formatParenthesis(parenthesis);
   }
 
   private formatArraySubscript({ array, parenthesis }: ArraySubscriptNode) {

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -186,7 +186,9 @@ export default class ExpressionFormatter {
   }
 
   private formatLimitClause(node: LimitClauseNode) {
-    this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.name));
+    this.withComments(node.name, () => {
+      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.name));
+    });
     this.layout.indentation.increaseTopLevel();
 
     if (isTabularStyle(this.cfg)) {

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -24,6 +24,7 @@ import {
   CommaNode,
   KeywordNode,
   PropertyAccessNode,
+  CommentNode,
 } from 'src/parser/ast';
 
 import Layout, { WS } from './Layout';
@@ -108,7 +109,9 @@ export default class ExpressionFormatter {
   }
 
   private formatArraySubscript({ array, parenthesis }: ArraySubscriptNode) {
+    this.formatComments(array.leadingComments);
     this.layout.add(array.type === NodeType.keyword ? this.showKw(array) : array.text);
+    this.formatComments(array.trailingComments);
     this.formatParenthesis(parenthesis);
   }
 
@@ -237,6 +240,19 @@ export default class ExpressionFormatter {
     } else {
       this.layout.add(WS.NO_SPACE, ',', WS.SPACE);
     }
+  }
+
+  private formatComments(comments: CommentNode[] | undefined) {
+    if (!comments) {
+      return;
+    }
+    comments.forEach(com => {
+      if (com.type === NodeType.line_comment) {
+        this.formatLineComment(com);
+      } else {
+        this.formatBlockComment(com);
+      }
+    });
   }
 
   private formatLineComment(node: LineCommentNode) {

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -104,21 +104,21 @@ export default class ExpressionFormatter {
   }
 
   private formatFunctionCall({ name, parenthesis }: FunctionCallNode) {
-    this.formatComments(name.leadingComments);
-    this.layout.add(this.showKw(name));
-    this.formatComments(name.trailingComments);
+    this.withComments(name, () => {
+      this.layout.add(this.showKw(name));
+    });
     this.formatParenthesis(parenthesis);
   }
 
   private formatArraySubscript(node: ArraySubscriptNode) {
-    this.formatComments(node.leadingComments);
-    this.formatComments(node.array.leadingComments);
-    this.layout.add(
-      node.array.type === NodeType.keyword ? this.showKw(node.array) : node.array.text
-    );
-    this.formatComments(node.array.trailingComments);
-    this.formatParenthesis(node.parenthesis);
-    this.formatComments(node.trailingComments);
+    this.withComments(node, () => {
+      this.withComments(node.array, () => {
+        this.layout.add(
+          node.array.type === NodeType.keyword ? this.showKw(node.array) : node.array.text
+        );
+      });
+      this.formatParenthesis(node.parenthesis);
+    });
   }
 
   private formatPropertyAccess({ object, property }: PropertyAccessNode) {
@@ -202,9 +202,9 @@ export default class ExpressionFormatter {
   }
 
   private formatAllColumnsAsterisk(node: AllColumnsAsteriskNode) {
-    this.formatComments(node.leadingComments);
-    this.layout.add('*', WS.SPACE);
-    this.formatComments(node.trailingComments);
+    this.withComments(node, () => {
+      this.layout.add('*', WS.SPACE);
+    });
   }
 
   private formatLiteral(node: LiteralNode) {
@@ -212,9 +212,9 @@ export default class ExpressionFormatter {
   }
 
   private formatIdentifier(node: IdentifierNode) {
-    this.formatComments(node.leadingComments);
-    this.layout.add(node.text, WS.SPACE);
-    this.formatComments(node.trailingComments);
+    this.withComments(node, () => {
+      this.layout.add(node.text, WS.SPACE);
+    });
   }
 
   private formatParameter(node: ParameterNode) {
@@ -250,6 +250,12 @@ export default class ExpressionFormatter {
     } else {
       this.layout.add(WS.NO_SPACE, ',', WS.SPACE);
     }
+  }
+
+  private withComments(node: AstNode, fn: () => void) {
+    this.formatComments(node.leadingComments);
+    fn();
+    this.formatComments(node.trailingComments);
   }
 
   private formatComments(comments: CommentNode[] | undefined) {

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -65,6 +65,12 @@ export default class ExpressionFormatter {
   }
 
   private formatNode(node: AstNode) {
+    this.formatComments(node.leadingComments);
+    this.formatNodeWithoutComments(node);
+    this.formatComments(node.trailingComments);
+  }
+
+  private formatNodeWithoutComments(node: AstNode) {
     switch (node.type) {
       case NodeType.function_call:
         return this.formatFunctionCall(node);
@@ -103,28 +109,26 @@ export default class ExpressionFormatter {
     }
   }
 
-  private formatFunctionCall({ name, parenthesis }: FunctionCallNode) {
-    this.withComments(name, () => {
-      this.layout.add(this.showKw(name));
+  private formatFunctionCall(node: FunctionCallNode) {
+    this.withComments(node.name, () => {
+      this.layout.add(this.showKw(node.name));
     });
-    this.formatParenthesis(parenthesis);
+    this.formatNode(node.parenthesis);
   }
 
   private formatArraySubscript(node: ArraySubscriptNode) {
-    this.withComments(node, () => {
-      this.withComments(node.array, () => {
-        this.layout.add(
-          node.array.type === NodeType.keyword ? this.showKw(node.array) : node.array.text
-        );
-      });
-      this.formatParenthesis(node.parenthesis);
+    this.withComments(node.array, () => {
+      this.layout.add(
+        node.array.type === NodeType.keyword ? this.showKw(node.array) : node.array.text
+      );
     });
+    this.formatNode(node.parenthesis);
   }
 
-  private formatPropertyAccess({ object, property }: PropertyAccessNode) {
-    this.formatNode(object);
+  private formatPropertyAccess(node: PropertyAccessNode) {
+    this.formatNode(node.object);
     this.layout.add(WS.NO_SPACE, '.');
-    this.formatNode(property);
+    this.formatNode(node.property);
   }
 
   private formatParenthesis(node: ParenthesisNode) {
@@ -201,10 +205,8 @@ export default class ExpressionFormatter {
     this.layout.indentation.decreaseTopLevel();
   }
 
-  private formatAllColumnsAsterisk(node: AllColumnsAsteriskNode) {
-    this.withComments(node, () => {
-      this.layout.add('*', WS.SPACE);
-    });
+  private formatAllColumnsAsterisk(_node: AllColumnsAsteriskNode) {
+    this.layout.add('*', WS.SPACE);
   }
 
   private formatLiteral(node: LiteralNode) {
@@ -212,9 +214,7 @@ export default class ExpressionFormatter {
   }
 
   private formatIdentifier(node: IdentifierNode) {
-    this.withComments(node, () => {
-      this.layout.add(node.text, WS.SPACE);
-    });
+    this.layout.add(node.text, WS.SPACE);
   }
 
   private formatParameter(node: ParameterNode) {

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -110,11 +110,15 @@ export default class ExpressionFormatter {
     this.formatParenthesis(parenthesis);
   }
 
-  private formatArraySubscript({ array, parenthesis }: ArraySubscriptNode) {
-    this.formatComments(array.leadingComments);
-    this.layout.add(array.type === NodeType.keyword ? this.showKw(array) : array.text);
-    this.formatComments(array.trailingComments);
-    this.formatParenthesis(parenthesis);
+  private formatArraySubscript(node: ArraySubscriptNode) {
+    this.formatComments(node.leadingComments);
+    this.formatComments(node.array.leadingComments);
+    this.layout.add(
+      node.array.type === NodeType.keyword ? this.showKw(node.array) : node.array.text
+    );
+    this.formatComments(node.array.trailingComments);
+    this.formatParenthesis(node.parenthesis);
+    this.formatComments(node.trailingComments);
   }
 
   private formatPropertyAccess({ object, property }: PropertyAccessNode) {
@@ -197,8 +201,10 @@ export default class ExpressionFormatter {
     this.layout.indentation.decreaseTopLevel();
   }
 
-  private formatAllColumnsAsterisk(_node: AllColumnsAsteriskNode) {
+  private formatAllColumnsAsterisk(node: AllColumnsAsteriskNode) {
+    this.formatComments(node.leadingComments);
     this.layout.add('*', WS.SPACE);
+    this.formatComments(node.trailingComments);
   }
 
   private formatLiteral(node: LiteralNode) {
@@ -206,7 +212,9 @@ export default class ExpressionFormatter {
   }
 
   private formatIdentifier(node: IdentifierNode) {
+    this.formatComments(node.leadingComments);
     this.layout.add(node.text, WS.SPACE);
+    this.formatComments(node.trailingComments);
   }
 
   private formatParameter(node: ParameterNode) {

--- a/src/lexer/disambiguateTokens.ts
+++ b/src/lexer/disambiguateTokens.ts
@@ -33,7 +33,7 @@ const dotKeywordToIdent = (token: Token, i: number, tokens: Token[]): Token => {
 
 const funcNameToKeyword = (token: Token, i: number, tokens: Token[]): Token => {
   if (token.type === TokenType.RESERVED_FUNCTION_NAME) {
-    const nextToken = tokens[i + 1];
+    const nextToken = nextNonCommentToken(tokens, i);
     if (!nextToken || !isOpenParen(nextToken)) {
       return { ...token, type: TokenType.RESERVED_KEYWORD };
     }

--- a/src/lexer/disambiguateTokens.ts
+++ b/src/lexer/disambiguateTokens.ts
@@ -23,7 +23,7 @@ export function disambiguateTokens(tokens: Token[]): Token[] {
 
 const dotKeywordToIdent = (token: Token, i: number, tokens: Token[]): Token => {
   if (isReserved(token.type)) {
-    const prevToken = tokens[i - 1];
+    const prevToken = prevNonCommentToken(tokens, i);
     if (prevToken && prevToken.text === '.') {
       return { ...token, type: TokenType.IDENTIFIER, text: token.raw };
     }
@@ -61,12 +61,19 @@ const keywordToArrayKeyword = (token: Token, i: number, tokens: Token[]): Token 
   return token;
 };
 
-const nextNonCommentToken = (tokens: Token[], index: number): Token | undefined => {
+const prevNonCommentToken = (tokens: Token[], index: number): Token | undefined =>
+  nextNonCommentToken(tokens, index, -1);
+
+const nextNonCommentToken = (
+  tokens: Token[],
+  index: number,
+  dir: -1 | 1 = 1
+): Token | undefined => {
   let i = 1;
-  while (tokens[index + i] && isComment(tokens[index + i])) {
+  while (tokens[index + i * dir] && isComment(tokens[index + i * dir])) {
     i++;
   }
-  return tokens[index + i];
+  return tokens[index + i * dir];
 };
 
 const isOpenParen = (t: Token): boolean => t.type === TokenType.OPEN_PAREN && t.text === '(';

--- a/src/lexer/disambiguateTokens.ts
+++ b/src/lexer/disambiguateTokens.ts
@@ -43,7 +43,7 @@ const funcNameToKeyword = (token: Token, i: number, tokens: Token[]): Token => {
 
 const identToArrayIdent = (token: Token, i: number, tokens: Token[]): Token => {
   if (token.type === TokenType.IDENTIFIER) {
-    const nextToken = tokens[i + 1];
+    const nextToken = nextNonCommentToken(tokens, i);
     if (nextToken && isOpenBracket(nextToken)) {
       return { ...token, type: TokenType.ARRAY_IDENTIFIER };
     }
@@ -53,7 +53,7 @@ const identToArrayIdent = (token: Token, i: number, tokens: Token[]): Token => {
 
 const keywordToArrayKeyword = (token: Token, i: number, tokens: Token[]): Token => {
   if (token.type === TokenType.RESERVED_KEYWORD) {
-    const nextToken = tokens[i + 1];
+    const nextToken = nextNonCommentToken(tokens, i);
     if (nextToken && isOpenBracket(nextToken)) {
       return { ...token, type: TokenType.ARRAY_KEYWORD };
     }
@@ -61,6 +61,17 @@ const keywordToArrayKeyword = (token: Token, i: number, tokens: Token[]): Token 
   return token;
 };
 
+const nextNonCommentToken = (tokens: Token[], index: number): Token | undefined => {
+  let i = 1;
+  while (tokens[index + i] && isComment(tokens[index + i])) {
+    i++;
+  }
+  return tokens[index + i];
+};
+
 const isOpenParen = (t: Token): boolean => t.type === TokenType.OPEN_PAREN && t.text === '(';
 
 const isOpenBracket = (t: Token): boolean => t.type === TokenType.OPEN_PAREN && t.text === '[';
+
+const isComment = (t: Token): boolean =>
+  t.type === TokenType.BLOCK_COMMENT || t.type === TokenType.LINE_COMMENT;

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -21,120 +21,120 @@ export enum NodeType {
   block_comment = 'block_comment',
 }
 
-type BaseNode = {
+interface BaseNode {
   leadingComments?: CommentNode[];
   trailingComments?: CommentNode[];
-};
+}
 
-export type StatementNode = BaseNode & {
+export interface StatementNode extends BaseNode {
   type: NodeType.statement;
   children: AstNode[];
   hasSemicolon: boolean;
-};
+}
 
-export type ClauseNode = BaseNode & {
+export interface ClauseNode extends BaseNode {
   type: NodeType.clause;
   name: KeywordNode;
   children: AstNode[];
-};
+}
 
-export type SetOperationNode = BaseNode & {
+export interface SetOperationNode extends BaseNode {
   type: NodeType.set_operation;
   name: KeywordNode;
   children: AstNode[];
-};
+}
 
-export type FunctionCallNode = BaseNode & {
+export interface FunctionCallNode extends BaseNode {
   type: NodeType.function_call;
   name: KeywordNode;
   parenthesis: ParenthesisNode;
-};
+}
 
 // <ident>[<expr>]
-export type ArraySubscriptNode = BaseNode & {
+export interface ArraySubscriptNode extends BaseNode {
   type: NodeType.array_subscript;
   array: IdentifierNode | KeywordNode;
   parenthesis: ParenthesisNode;
-};
+}
 
-export type ParenthesisNode = BaseNode & {
+export interface ParenthesisNode extends BaseNode {
   type: NodeType.parenthesis;
   children: AstNode[];
   openParen: string;
   closeParen: string;
-};
+}
 
 // BETWEEN <expr1> AND <expr2>
-export type BetweenPredicateNode = BaseNode & {
+export interface BetweenPredicateNode extends BaseNode {
   type: NodeType.between_predicate;
   between: KeywordNode;
   expr1: AstNode[];
   and: KeywordNode;
   expr2: AstNode[];
-};
+}
 
 // LIMIT <count>
 // LIMIT <offset>, <count>
-export type LimitClauseNode = BaseNode & {
+export interface LimitClauseNode extends BaseNode {
   type: NodeType.limit_clause;
   name: KeywordNode;
   count: AstNode[];
   offset?: AstNode[];
-};
+}
 
 // The "*" operator used in SELECT *
-export type AllColumnsAsteriskNode = BaseNode & {
+export interface AllColumnsAsteriskNode extends BaseNode {
   type: NodeType.all_columns_asterisk;
-};
+}
 
-export type LiteralNode = BaseNode & {
+export interface LiteralNode extends BaseNode {
   type: NodeType.literal;
   text: string;
-};
+}
 
-export type PropertyAccessNode = BaseNode & {
+export interface PropertyAccessNode extends BaseNode {
   type: NodeType.property_access;
   object: AstNode;
   property: IdentifierNode | ArraySubscriptNode | AllColumnsAsteriskNode;
-};
+}
 
-export type IdentifierNode = BaseNode & {
+export interface IdentifierNode extends BaseNode {
   type: NodeType.identifier;
   text: string;
-};
+}
 
-export type KeywordNode = BaseNode & {
+export interface KeywordNode extends BaseNode {
   type: NodeType.keyword;
   tokenType: TokenType;
   text: string;
   raw: string;
-};
+}
 
-export type ParameterNode = BaseNode & {
+export interface ParameterNode extends BaseNode {
   type: NodeType.parameter;
   key?: string;
   text: string;
-};
+}
 
-export type OperatorNode = BaseNode & {
+export interface OperatorNode extends BaseNode {
   type: NodeType.operator;
   text: string;
-};
+}
 
-export type CommaNode = BaseNode & {
+export interface CommaNode extends BaseNode {
   type: NodeType.comma;
-};
+}
 
-export type LineCommentNode = BaseNode & {
+export interface LineCommentNode extends BaseNode {
   type: NodeType.line_comment;
   text: string;
   precedingWhitespace: string;
-};
+}
 
-export type BlockCommentNode = BaseNode & {
+export interface BlockCommentNode extends BaseNode {
   type: NodeType.block_comment;
   text: string;
-};
+}
 
 export type CommentNode = LineCommentNode | BlockCommentNode;
 

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -21,38 +21,43 @@ export enum NodeType {
   block_comment = 'block_comment',
 }
 
-export type StatementNode = {
+type BaseNode = {
+  leadingComments?: CommentNode[];
+  trailingComments?: CommentNode[];
+};
+
+export type StatementNode = BaseNode & {
   type: NodeType.statement;
   children: AstNode[];
   hasSemicolon: boolean;
 };
 
-export type ClauseNode = {
+export type ClauseNode = BaseNode & {
   type: NodeType.clause;
   name: KeywordNode;
   children: AstNode[];
 };
 
-export type SetOperationNode = {
+export type SetOperationNode = BaseNode & {
   type: NodeType.set_operation;
   name: KeywordNode;
   children: AstNode[];
 };
 
-export type FunctionCallNode = {
+export type FunctionCallNode = BaseNode & {
   type: NodeType.function_call;
   name: KeywordNode;
   parenthesis: ParenthesisNode;
 };
 
 // <ident>[<expr>]
-export type ArraySubscriptNode = {
+export type ArraySubscriptNode = BaseNode & {
   type: NodeType.array_subscript;
   array: IdentifierNode | KeywordNode;
   parenthesis: ParenthesisNode;
 };
 
-export type ParenthesisNode = {
+export type ParenthesisNode = BaseNode & {
   type: NodeType.parenthesis;
   children: AstNode[];
   openParen: string;
@@ -60,7 +65,7 @@ export type ParenthesisNode = {
 };
 
 // BETWEEN <expr1> AND <expr2>
-export type BetweenPredicateNode = {
+export type BetweenPredicateNode = BaseNode & {
   type: NodeType.between_predicate;
   between: KeywordNode;
   expr1: AstNode[];
@@ -70,7 +75,7 @@ export type BetweenPredicateNode = {
 
 // LIMIT <count>
 // LIMIT <offset>, <count>
-export type LimitClauseNode = {
+export type LimitClauseNode = BaseNode & {
   type: NodeType.limit_clause;
   name: KeywordNode;
   count: AstNode[];
@@ -78,58 +83,60 @@ export type LimitClauseNode = {
 };
 
 // The "*" operator used in SELECT *
-export type AllColumnsAsteriskNode = {
+export type AllColumnsAsteriskNode = BaseNode & {
   type: NodeType.all_columns_asterisk;
 };
 
-export type LiteralNode = {
+export type LiteralNode = BaseNode & {
   type: NodeType.literal;
   text: string;
 };
 
-export type PropertyAccessNode = {
+export type PropertyAccessNode = BaseNode & {
   type: NodeType.property_access;
   object: AstNode;
   property: IdentifierNode | ArraySubscriptNode | AllColumnsAsteriskNode;
 };
 
-export type IdentifierNode = {
+export type IdentifierNode = BaseNode & {
   type: NodeType.identifier;
   text: string;
 };
 
-export type KeywordNode = {
+export type KeywordNode = BaseNode & {
   type: NodeType.keyword;
   tokenType: TokenType;
   text: string;
   raw: string;
 };
 
-export type ParameterNode = {
+export type ParameterNode = BaseNode & {
   type: NodeType.parameter;
   key?: string;
   text: string;
 };
 
-export type OperatorNode = {
+export type OperatorNode = BaseNode & {
   type: NodeType.operator;
   text: string;
 };
 
-export type CommaNode = {
+export type CommaNode = BaseNode & {
   type: NodeType.comma;
 };
 
-export type LineCommentNode = {
+export type LineCommentNode = BaseNode & {
   type: NodeType.line_comment;
   text: string;
   precedingWhitespace: string;
 };
 
-export type BlockCommentNode = {
+export type BlockCommentNode = BaseNode & {
   type: NodeType.block_comment;
   text: string;
 };
+
+export type CommentNode = LineCommentNode | BlockCommentNode;
 
 export type AstNode =
   | ClauseNode

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -125,17 +125,17 @@ simple_expression ->
   | literal
   | keyword ) {% unwrap %}
 
-array_subscript -> %ARRAY_IDENTIFIER square_brackets {%
-  ([arrayToken, brackets]) => ({
+array_subscript -> %ARRAY_IDENTIFIER _ square_brackets {%
+  ([arrayToken, _, brackets]) => ({
     type: NodeType.array_subscript,
-    array: { type: NodeType.identifier, text: arrayToken.text },
+    array: { type: NodeType.identifier, text: arrayToken.text, trailingComments: _ },
     parenthesis: brackets,
   })
 %}
-array_subscript -> %ARRAY_KEYWORD square_brackets {%
-  ([arrayToken, brackets]) => ({
+array_subscript -> %ARRAY_KEYWORD _ square_brackets {%
+  ([arrayToken, _, brackets]) => ({
     type: NodeType.array_subscript,
-    array: toKeywordNode(arrayToken),
+    array: { ...toKeywordNode(arrayToken), trailingComments: _ },
     parenthesis: brackets,
   })
 %}
@@ -232,6 +232,8 @@ keyword ->
   | %XOR ) {%
   ([[token]]) => toKeywordNode(token)
 %}
+
+_ -> comment:* {% ([comments]) => comments %}
 
 comment -> %LINE_COMMENT {%
   ([token]) => ({

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -65,20 +65,20 @@ clause ->
   | other_clause
   | set_operation ) {% unwrap %}
 
-limit_clause -> %LIMIT commaless_expression:+ (%COMMA expression:+):? {%
-  ([limitToken, exp1, optional]) => {
+limit_clause -> %LIMIT _ expression_with_comments:+ (%COMMA expression:+):? {%
+  ([limitToken, _, exp1, optional]) => {
     if (optional) {
       const [comma, exp2] = optional;
       return {
         type: NodeType.limit_clause,
-        name: toKeywordNode(limitToken),
+        name: addTrailingComments(toKeywordNode(limitToken), _),
         offset: exp1,
         count: exp2,
       };
     } else {
       return {
         type: NodeType.limit_clause,
-        name: toKeywordNode(limitToken),
+        name: addTrailingComments(toKeywordNode(limitToken), _),
         count: exp1,
       };
     }
@@ -113,11 +113,13 @@ set_operation -> %RESERVED_SET_OPERATION expression:* {%
   })
 %}
 
+expression_with_comments -> (simple_expression | asterisk) _ {%
+  ([[expr], _]) => addTrailingComments(expr, _)
+%}
+
 expression -> ( simple_expression | between_predicate | asterisk | comma | comment ) {% unwrap %}
 
 asteriskless_expression -> ( simple_expression | between_predicate | comma | comment ) {% unwrap %}
-
-commaless_expression -> ( simple_expression | between_predicate | asterisk | comment ) {% unwrap %}
 
 simple_expression ->
   ( array_subscript

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -175,16 +175,16 @@ square_brackets -> "[" expression:* "]" {%
   })
 %}
 
-property_access -> simple_expression %DOT _ (identifier | array_subscript | all_columns_asterisk) {%
+property_access -> simple_expression _ %DOT _ (identifier | array_subscript | all_columns_asterisk) {%
   // Allowing property to be <array_subscript> is currently a hack.
   // A better way would be to allow <property_access> on the left side of array_subscript,
   // but we currently can't do that because of another hack that requires
   // %ARRAY_IDENTIFIER on the left side of <array_subscript>.
-  ([object, dot, _, [property]]) => {
+  ([object, _1, dot, _2, [property]]) => {
     return {
       type: NodeType.property_access,
-      object,
-      property: { ...property, leadingComments: _ },
+      object: { ...object, trailingComments: _1 },
+      property: { ...property, leadingComments: _2 },
     };
   }
 %}

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -196,13 +196,13 @@ property_access -> simple_expression _ %DOT _ (identifier | array_subscript | al
   }
 %}
 
-between_predicate -> %BETWEEN commaless_expression %AND commaless_expression {%
-  ([betweenToken, expr1, andToken, expr2]) => ({
+between_predicate -> %BETWEEN _ simple_expression _ %AND _ simple_expression {%
+  ([betweenToken, _1, expr1, _2, andToken, _3, expr2]) => ({
     type: NodeType.between_predicate,
     between: toKeywordNode(betweenToken),
-    expr1: [expr1],
+    expr1: [addTrailingComments(addLeadingComments(expr1, _1), _2)],
     and: toKeywordNode(andToken),
-    expr2: [expr2],
+    expr2: [addLeadingComments(expr2, _3)],
   })
 %}
 

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -140,10 +140,10 @@ array_subscript -> %ARRAY_KEYWORD _ square_brackets {%
   })
 %}
 
-function_call -> %RESERVED_FUNCTION_NAME parenthesis {%
-  ([nameToken, parens]) => ({
+function_call -> %RESERVED_FUNCTION_NAME _ parenthesis {%
+  ([nameToken, _, parens]) => ({
     type: NodeType.function_call,
-    name: toKeywordNode(nameToken),
+    name: { ...toKeywordNode(nameToken), trailingComments: _ },
     parenthesis: parens,
   })
 %}

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -119,7 +119,12 @@ simple_expression ->
   | parenthesis
   | curly_braces
   | square_brackets
-  | expression_token ) {% unwrap %}
+  | operator
+  | identifier
+  | parameter
+  | literal
+  | keyword
+  | comment ) {% unwrap %}
 
 array_subscript -> %ARRAY_IDENTIFIER square_brackets {%
   ([arrayToken, brackets]) => ({
@@ -198,14 +203,6 @@ between_predicate -> %BETWEEN commaless_expression %AND commaless_expression {%
 comma -> ( %COMMA ) {% ([[token]]) => ({ type: NodeType.comma }) %}
 
 asterisk -> ( %ASTERISK ) {% ([[token]]) => ({ type: NodeType.operator, text: token.text }) %}
-
-expression_token ->
-  ( operator
-  | identifier
-  | parameter
-  | literal
-  | keyword
-  | comment ) {% unwrap %}
 
 operator -> ( %OPERATOR ) {% ([[token]]) => ({ type: NodeType.operator, text: token.text }) %}
 

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -106,11 +106,11 @@ set_operation -> %RESERVED_SET_OPERATION expression:* {%
   })
 %}
 
-expression -> ( simple_expression | between_predicate | asterisk | comma ) {% unwrap %}
+expression -> ( simple_expression | between_predicate | asterisk | comma | comment ) {% unwrap %}
 
-asteriskless_expression -> ( simple_expression | between_predicate | comma ) {% unwrap %}
+asteriskless_expression -> ( simple_expression | between_predicate | comma | comment ) {% unwrap %}
 
-commaless_expression -> ( simple_expression | between_predicate | asterisk ) {% unwrap %}
+commaless_expression -> ( simple_expression | between_predicate | asterisk | comment ) {% unwrap %}
 
 simple_expression ->
   ( array_subscript
@@ -123,8 +123,7 @@ simple_expression ->
   | identifier
   | parameter
   | literal
-  | keyword
-  | comment ) {% unwrap %}
+  | keyword ) {% unwrap %}
 
 array_subscript -> %ARRAY_IDENTIFIER square_brackets {%
   ([arrayToken, brackets]) => ({

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -175,16 +175,16 @@ square_brackets -> "[" expression:* "]" {%
   })
 %}
 
-property_access -> simple_expression %DOT (identifier | array_subscript | all_columns_asterisk) {%
+property_access -> simple_expression %DOT _ (identifier | array_subscript | all_columns_asterisk) {%
   // Allowing property to be <array_subscript> is currently a hack.
   // A better way would be to allow <property_access> on the left side of array_subscript,
   // but we currently can't do that because of another hack that requires
   // %ARRAY_IDENTIFIER on the left side of <array_subscript>.
-  ([object, dot, [property]]) => {
+  ([object, dot, _, [property]]) => {
     return {
       type: NodeType.property_access,
       object,
-      property,
+      property: { ...property, leadingComments: _ },
     };
   }
 %}

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -113,15 +113,17 @@ set_operation -> %RESERVED_SET_OPERATION expression:* {%
   })
 %}
 
-expression_with_comments -> (simple_expression | asterisk) _ {%
-  ([[expr], _]) => addTrailingComments(expr, _)
+expression_with_comments -> simple_expression _ {%
+  ([expr, _]) => addTrailingComments(expr, _)
 %}
 
-expression -> ( simple_expression | between_predicate | asterisk | comma | comment ) {% unwrap %}
+expression -> ( simple_expression | between_predicate | comma | comment ) {% unwrap %}
 
-asteriskless_expression -> ( simple_expression | between_predicate | comma | comment ) {% unwrap %}
+asteriskless_expression -> ( simple_expression_without_asterisk | between_predicate | comma | comment ) {% unwrap %}
 
-simple_expression ->
+simple_expression -> ( simple_expression_without_asterisk | asterisk ) {% unwrap %}
+
+simple_expression_without_asterisk ->
   ( array_subscript
   | function_call
   | property_access

--- a/test/features/arrayAndMapAccessors.ts
+++ b/test/features/arrayAndMapAccessors.ts
@@ -40,4 +40,14 @@ export default function supportsArrayAndMapAccessors(format: FormatFn) {
         [1];
     `);
   });
+
+  it('formats namespaced array accessor with comment in-between', () => {
+    const result = format(`SELECT foo./* comment */arr[1];`);
+    expect(result).toBe(dedent`
+      SELECT
+        foo.
+        /* comment */
+        arr[1];
+    `);
+  });
 }

--- a/test/features/arrayAndMapAccessors.ts
+++ b/test/features/arrayAndMapAccessors.ts
@@ -30,4 +30,14 @@ export default function supportsArrayAndMapAccessors(format: FormatFn) {
         foo.coalesce['blah'];
     `);
   });
+
+  it('formats array accessor with comment in-between', () => {
+    const result = format(`SELECT arr /* comment */ [1];`);
+    expect(result).toBe(dedent`
+      SELECT
+        arr
+        /* comment */
+        [1];
+    `);
+  });
 }

--- a/test/features/between.ts
+++ b/test/features/between.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent-js';
 import { FormatFn } from 'src/sqlFormatter';
 
 export default function supportsBetween(format: FormatFn) {
@@ -7,5 +8,18 @@ export default function supportsBetween(format: FormatFn) {
 
   it('supports qualified.names as BETWEEN expression values', () => {
     expect(format('foo BETWEEN t.bar AND t.baz')).toBe('foo BETWEEN t.bar AND t.baz');
+  });
+
+  it('formats BETWEEN with comments inside', () => {
+    expect(format('WHERE foo BETWEEN /*C1*/ t.bar /*C2*/ AND /*C3*/ t.baz')).toBe(dedent`
+      WHERE
+        foo BETWEEN
+        /*C1*/
+        t.bar
+        /*C2*/
+       AND
+        /*C3*/
+        t.baz
+    `);
   });
 }

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -161,6 +161,18 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
     `);
   });
 
+  it('formats comments between function name and parenthesis', () => {
+    const result = format(`
+      SELECT count /* comment */ (*);
+    `);
+    expect(result).toBe(dedent`
+      SELECT
+        count
+        /* comment */
+        (*);
+    `);
+  });
+
   if (opts.hashComments) {
     it('supports # line comment', () => {
       const result = format('SELECT alpha # commment\nFROM beta');

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -173,7 +173,28 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
     `);
   });
 
-  it('formats comments between qualified.names', () => {
+  it('formats comments between qualified.names (before dot)', () => {
+    const result = format(`
+      SELECT foo/* com1 */.bar, count()/* com2 */.bar, foo.bar/* com3 */.baz, (1, 2) /* com4 */.foo;
+    `);
+    expect(result).toBe(dedent`
+      SELECT
+        foo
+        /* com1 */
+      .bar,
+        count()
+        /* com2 */
+      .bar,
+        foo.bar
+        /* com3 */
+      .baz,
+        (1, 2)
+        /* com4 */
+      .foo;
+    `);
+  });
+
+  it('formats comments between qualified.names (after dot)', () => {
     const result = format(`
       SELECT foo. /* com1 */ bar, foo. /* com2 */ *;
     `);

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -173,6 +173,21 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
     `);
   });
 
+  it('formats comments between qualified.names', () => {
+    const result = format(`
+      SELECT foo. /* com1 */ bar, foo. /* com2 */ *;
+    `);
+    expect(result).toBe(dedent`
+      SELECT
+        foo.
+        /* com1 */
+        bar,
+        foo.
+        /* com2 */
+        *;
+    `);
+  });
+
   if (opts.hashComments) {
     it('supports # line comment', () => {
       const result = format('SELECT alpha # commment\nFROM beta');

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -36,6 +36,10 @@ describe('Parser', () => {
     expect(parse('SELECT my_array[5]')).toMatchSnapshot();
   });
 
+  it('parses array subscript with comment', () => {
+    expect(parse('SELECT my_array /*haha*/ [5]')).toMatchSnapshot();
+  });
+
   it('parses parenthesized expressions', () => {
     expect(parse('SELECT (birth_year - (CURRENT_DATE + 1))')).toMatchSnapshot();
   });

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -355,6 +355,7 @@ Array [
               "raw": "sqrt",
               "text": "SQRT",
               "tokenType": "RESERVED_FUNCTION_NAME",
+              "trailingComments": Array [],
               "type": "keyword",
             },
             "parenthesis": Object {
@@ -410,6 +411,7 @@ Array [
               "raw": "CURRENT_TIME",
               "text": "CURRENT_TIME",
               "tokenType": "RESERVED_FUNCTION_NAME",
+              "trailingComments": Array [],
               "type": "keyword",
             },
             "parenthesis": Object {

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -193,11 +193,9 @@ Array [
           Object {
             "object": Object {
               "text": "ident",
-              "trailingComments": Array [],
               "type": "identifier",
             },
             "property": Object {
-              "leadingComments": Array [],
               "type": "all_columns_asterisk",
             },
             "type": "property_access",
@@ -227,7 +225,6 @@ Array [
           Object {
             "array": Object {
               "text": "my_array",
-              "trailingComments": Array [],
               "type": "identifier",
             },
             "parenthesis": Object {
@@ -357,7 +354,6 @@ Array [
               "raw": "sqrt",
               "text": "SQRT",
               "tokenType": "RESERVED_FUNCTION_NAME",
-              "trailingComments": Array [],
               "type": "keyword",
             },
             "parenthesis": Object {
@@ -413,7 +409,6 @@ Array [
               "raw": "CURRENT_TIME",
               "text": "CURRENT_TIME",
               "tokenType": "RESERVED_FUNCTION_NAME",
-              "trailingComments": Array [],
               "type": "keyword",
             },
             "parenthesis": Object {
@@ -535,19 +530,15 @@ Array [
             "object": Object {
               "object": Object {
                 "text": "foo",
-                "trailingComments": Array [],
                 "type": "identifier",
               },
               "property": Object {
-                "leadingComments": Array [],
                 "text": "bar",
                 "type": "identifier",
               },
-              "trailingComments": Array [],
               "type": "property_access",
             },
             "property": Object {
-              "leadingComments": Array [],
               "text": "baz",
               "type": "identifier",
             },

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -225,6 +225,53 @@ Array [
           Object {
             "array": Object {
               "text": "my_array",
+              "trailingComments": Array [],
+              "type": "identifier",
+            },
+            "parenthesis": Object {
+              "children": Array [
+                Object {
+                  "text": "5",
+                  "type": "literal",
+                },
+              ],
+              "closeParen": "]",
+              "openParen": "[",
+              "type": "parenthesis",
+            },
+            "type": "array_subscript",
+          },
+        ],
+        "name": Object {
+          "raw": "SELECT",
+          "text": "SELECT",
+          "tokenType": "RESERVED_SELECT",
+          "type": "keyword",
+        },
+        "type": "clause",
+      },
+    ],
+    "hasSemicolon": false,
+    "type": "statement",
+  },
+]
+`;
+
+exports[`Parser parses array subscript with comment 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "array": Object {
+              "text": "my_array",
+              "trailingComments": Array [
+                Object {
+                  "text": "/*haha*/",
+                  "type": "block_comment",
+                },
+              ],
               "type": "identifier",
             },
             "parenthesis": Object {

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -193,6 +193,7 @@ Array [
           Object {
             "object": Object {
               "text": "ident",
+              "trailingComments": Array [],
               "type": "identifier",
             },
             "property": Object {
@@ -534,6 +535,7 @@ Array [
             "object": Object {
               "object": Object {
                 "text": "foo",
+                "trailingComments": Array [],
                 "type": "identifier",
               },
               "property": Object {
@@ -541,6 +543,7 @@ Array [
                 "text": "bar",
                 "type": "identifier",
               },
+              "trailingComments": Array [],
               "type": "property_access",
             },
             "property": Object {

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -196,6 +196,7 @@ Array [
               "type": "identifier",
             },
             "property": Object {
+              "leadingComments": Array [],
               "type": "all_columns_asterisk",
             },
             "type": "property_access",
@@ -536,12 +537,14 @@ Array [
                 "type": "identifier",
               },
               "property": Object {
+                "leadingComments": Array [],
                 "text": "bar",
                 "type": "identifier",
               },
               "type": "property_access",
             },
             "property": Object {
+              "leadingComments": Array [],
               "text": "baz",
               "type": "identifier",
             },


### PR DESCRIPTION
Added two optional fields to each node:

- `leadingComments`
- `trailingComments`

Chose these names after babel-eslint9 parser (see in [astexplorer page](https://astexplorer.net/)), which also adds comment data to its AST in similar fashion.

Instead of throwing removing comment tokens from token stream, and then later attempting to re-associate them with AST nodes based on the locations (which was my original idea that I tried to explore in #436) the comments are now intentionally picked up during parsing. Commonly with a pattern like:

```
between_predicate -> %BETWEEN _ simple_expression _ %AND _ simple_expression
```

Where `_` stands for optional comments which, when present, get added to `leading/trailingComments` field of nodes.

This approach seems quite promising. At least I got it working for several node types. Unlike with the locations approach where I realized it's either going to be really hard or maybe not even possible at all. Plus, I've already managed to add support for comments in places where previously a comment would have caused a crash.

For now there are still "free floating" comments which aren't inside `leading/trailingComments` fields. These should go away eventually as the AST evolves into a more correct form. For now they're still there and I'm not planning to eliminate them within this PR.

The formatting of many of these in-between comments is also not quite good. Again, I'm not gonna tackle that problem within this PR. These badly-formatted comments are still way better than comments that crash the parser. And these comments are mostly pretty odd cases like `table /*comment*/ . /*comment*/ column` which should occur pretty rarely.