### PR TITLE
Include line & column number to Tokenizer and Parser errors

### DIFF
--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -1,4 +1,5 @@
 import { Token, TokenType } from 'src/lexer/token';
+import { lineColFromIndex } from './lineColFromIndex';
 import { WHITESPACE_REGEX } from './regexUtil';
 
 export interface RegExpLike {
@@ -55,7 +56,9 @@ export default class TokenizerEngine {
   }
 
   private createParseError(): Error {
-    return new Error(`Parse error: Unexpected "${this.input.slice(this.index, 100)}"`);
+    const text = this.input.slice(this.index, this.index + 10);
+    const { line, col } = lineColFromIndex(this.input, this.index);
+    return new Error(`Parse error: Unexpected "${text}" at line ${line} column ${col}`);
   }
 
   private getWhitespace(): string | undefined {

--- a/src/lexer/TokenizerEngine.ts
+++ b/src/lexer/TokenizerEngine.ts
@@ -45,13 +45,17 @@ export default class TokenizerEngine {
         // Get the next token and the token type
         token = this.getNextToken();
         if (!token) {
-          throw new Error(`Parse error: Unexpected "${input.slice(this.index, 100)}"`);
+          throw this.createParseError();
         }
 
         tokens.push({ ...token, precedingWhitespace });
       }
     }
     return tokens;
+  }
+
+  private createParseError(): Error {
+    return new Error(`Parse error: Unexpected "${this.input.slice(this.index, 100)}"`);
   }
 
   private getWhitespace(): string | undefined {

--- a/src/lexer/lineColFromIndex.ts
+++ b/src/lexer/lineColFromIndex.ts
@@ -1,0 +1,9 @@
+/**
+ * Determines line and column number of character index in source code.
+ */
+export function lineColFromIndex(source: string, index: number): LineCol {
+  const lines = source.slice(0, index).split(/\n/);
+  return { line: lines.length, col: lines[lines.length - 1].length + 1 };
+}
+
+export type LineCol = { line: number; col: number };

--- a/src/lexer/lineColFromIndex.ts
+++ b/src/lexer/lineColFromIndex.ts
@@ -6,4 +6,7 @@ export function lineColFromIndex(source: string, index: number): LineCol {
   return { line: lines.length, col: lines[lines.length - 1].length + 1 };
 }
 
-export type LineCol = { line: number; col: number };
+export interface LineCol {
+  line: number;
+  col: number;
+}

--- a/src/parser/LexerAdapter.ts
+++ b/src/parser/LexerAdapter.ts
@@ -1,3 +1,4 @@
+import { lineColFromIndex } from 'src/lexer/lineColFromIndex';
 import { Token, TokenType } from 'src/lexer/token';
 
 // Nearly type definitions say that Token must have a value field,
@@ -7,10 +8,12 @@ type NearleyToken = Token & { value: string };
 export default class LexerAdapter {
   private index = 0;
   private tokens: Token[] = [];
+  private input = '';
 
   constructor(private tokenize: (chunk: string) => Token[]) {}
 
   reset(chunk: string, _info: any) {
+    this.input = chunk;
     this.index = 0;
     this.tokens = this.tokenize(chunk);
   }
@@ -22,7 +25,8 @@ export default class LexerAdapter {
   save(): any {}
 
   formatError(token: NearleyToken) {
-    return `Parse error at token: ${token.text}`;
+    const { line, col } = lineColFromIndex(this.input, token.loc.start);
+    return `Parse error at token: ${token.text} at line ${line} column ${col}`;
   }
 
   has(name: string): boolean {

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -57,16 +57,17 @@ describe('SqlFormatter', () => {
 
   it('throws error when encountering characters or operators it does not recognize', () => {
     expect(() => format('SELECT @name, :bar FROM foo;')).toThrowError(
-      `Parse error: Unexpected "@name, :bar FROM foo;"`
+      `Parse error: Unexpected "@name, :ba" at line 1 column 8`
     );
   });
 
   it('crashes when encountering unsupported curly braces', () => {
     expect(() =>
-      format(`
-        SELECT {foo};
+      format(dedent`
+        SELECT
+          {foo};
       `)
-    ).toThrowError('Parse error: Unexpected "{foo};');
+    ).toThrowError('Parse error: Unexpected "{foo};" at line 2 column 3');
   });
 
   it('formats ALTER TABLE ... ALTER COLUMN', () => {

--- a/test/sqlFormatter.test.ts
+++ b/test/sqlFormatter.test.ts
@@ -16,6 +16,10 @@ describe('sqlFormatter', () => {
     }).toThrow('Parse error: Unexpected "«weird-stu" at line 1 column 8');
   });
 
+  it('throws error when encountering incorrect SQL grammar', () => {
+    expect(() => format('SELECT foo.+;')).toThrow('Parse error at token: + at line 1 column 12');
+  });
+
   it('does nothing with empty input', () => {
     const result = format('');
 

--- a/test/sqlFormatter.test.ts
+++ b/test/sqlFormatter.test.ts
@@ -13,7 +13,7 @@ describe('sqlFormatter', () => {
   it('throws error when encountering unsupported characters', () => {
     expect(() => {
       format('SELECT «weird-stuff»');
-    }).toThrow('Parse error: Unexpected "«weird-stuff»"');
+    }).toThrow('Parse error: Unexpected "«weird-stu" at line 1 column 8');
   });
 
   it('does nothing with empty input', () => {


### PR DESCRIPTION
Created `lineColFromIndex()` helper, which computes line & column number from character index in source code.