### PR TITLE
Improve CASE expression formatting

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -350,9 +350,6 @@ export default class ExpressionFormatter {
     switch (node.tokenType) {
       case TokenType.RESERVED_JOIN:
         return this.formatJoin(node);
-      case TokenType.WHEN:
-      case TokenType.ELSE:
-        return this.formatDependentClause(node);
       case TokenType.AND:
       case TokenType.OR:
       case TokenType.XOR:
@@ -365,6 +362,9 @@ export default class ExpressionFormatter {
         return this.formatCaseStart(node);
       case TokenType.END:
         return this.formatCaseEnd(node);
+      case TokenType.WHEN:
+      case TokenType.ELSE:
+        return this.formatCaseWhenOrElse(node);
       default:
         throw new Error(`Unexpected token type: ${node.tokenType}`);
     }
@@ -385,7 +385,7 @@ export default class ExpressionFormatter {
     this.layout.add(this.showKw(node), WS.SPACE);
   }
 
-  private formatDependentClause(node: KeywordNode) {
+  private formatCaseWhenOrElse(node: KeywordNode) {
     this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node), WS.SPACE);
   }
 

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -357,6 +357,7 @@ export default class ExpressionFormatter {
       case TokenType.RESERVED_KEYWORD:
       case TokenType.RESERVED_FUNCTION_NAME:
       case TokenType.RESERVED_PHRASE:
+      case TokenType.THEN:
         return this.formatKeyword(node);
       case TokenType.CASE:
         return this.formatCaseStart(node);

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -350,7 +350,8 @@ export default class ExpressionFormatter {
     switch (node.tokenType) {
       case TokenType.RESERVED_JOIN:
         return this.formatJoin(node);
-      case TokenType.RESERVED_DEPENDENT_CLAUSE:
+      case TokenType.WHEN:
+      case TokenType.ELSE:
         return this.formatDependentClause(node);
       case TokenType.AND:
       case TokenType.OR:

--- a/src/formatter/tabularStyle.ts
+++ b/src/formatter/tabularStyle.ts
@@ -31,7 +31,6 @@ export default function toTabularFormat(tokenText: string, indentStyle: IndentSt
 export function isTabularToken(type: TokenType): boolean {
   return (
     isLogicalOperator(type) ||
-    type === TokenType.RESERVED_DEPENDENT_CLAUSE ||
     type === TokenType.RESERVED_COMMAND ||
     type === TokenType.RESERVED_SELECT ||
     type === TokenType.RESERVED_SET_OPERATION ||

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -147,7 +147,6 @@ export default class BigQueryFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -176,7 +176,6 @@ export default class Db2Formatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -176,7 +176,7 @@ export default class Db2Formatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE', 'ELSEIF'],
+      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/db2/db2.keywords.ts
+++ b/src/languages/db2/db2.keywords.ts
@@ -65,6 +65,8 @@ export const keywords = flatKeywordList({
     'DSSIZE',
     'DYNAMIC',
     'EDITPROC',
+    'ELSE',
+    'ELSEIF',
     'ENCODING',
     'ENCRYPTION',
     'ENDING',

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -88,7 +88,6 @@ export default class HiveFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -268,7 +268,7 @@ export default class MariaDbFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE', 'ELSEIF', 'ELSIF'],
+      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       supportsXor: true,
       reservedKeywords: keywords,

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -268,7 +268,6 @@ export default class MariaDbFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       supportsXor: true,
       reservedKeywords: keywords,

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -236,7 +236,7 @@ export default class MySqlFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE', 'ELSEIF'],
+      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       supportsXor: true,
       reservedKeywords: keywords,

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -236,7 +236,6 @@ export default class MySqlFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       supportsXor: true,
       reservedKeywords: keywords,

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -85,7 +85,6 @@ export default class N1qlFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       supportsXor: true,
       reservedKeywords: keywords,

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -85,7 +85,6 @@ export default class PlSqlFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       supportsXor: true,
       reservedKeywords: keywords,

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -253,7 +253,6 @@ export default class PostgreSqlFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -146,7 +146,6 @@ export default class RedshiftFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -237,7 +237,7 @@ export default class SingleStoreDbFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE', 'ELSEIF'],
+      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -237,7 +237,6 @@ export default class SingleStoreDbFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -123,7 +123,6 @@ export default class SparkFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       supportsXor: true,
       reservedKeywords: keywords,

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -74,7 +74,6 @@ export default class SqlFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -67,7 +67,6 @@ export default class SqliteFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -220,7 +220,6 @@ export default class TransactSqlFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -126,7 +126,6 @@ export default class TrinoFormatter extends Formatter {
       reservedSelect,
       reservedSetOperations,
       reservedJoins,
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedPhrases,
       reservedKeywords: keywords,
       reservedFunctionNames: functions,

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -91,8 +91,13 @@ export default class Tokenizer {
         text: toCanonical,
       },
       {
-        type: TokenType.RESERVED_DEPENDENT_CLAUSE,
-        regex: regex.reservedWord(['WHEN', 'ELSE'], cfg.identChars),
+        type: TokenType.WHEN,
+        regex: /WHEN\b/iuy,
+        text: toCanonical,
+      },
+      {
+        type: TokenType.ELSE,
+        regex: /ELSE\b/iuy,
         text: toCanonical,
       },
       {

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -101,6 +101,11 @@ export default class Tokenizer {
         text: toCanonical,
       },
       {
+        type: TokenType.THEN,
+        regex: /THEN\b/iuy,
+        text: toCanonical,
+      },
+      {
         type: TokenType.RESERVED_JOIN,
         regex: regex.reservedWord(cfg.reservedJoins, cfg.identChars),
         text: toCanonical,

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -92,7 +92,7 @@ export default class Tokenizer {
       },
       {
         type: TokenType.RESERVED_DEPENDENT_CLAUSE,
-        regex: regex.reservedWord(cfg.reservedDependentClauses, cfg.identChars),
+        regex: regex.reservedWord(['WHEN', 'ELSE'], cfg.identChars),
         text: toCanonical,
       },
       {

--- a/src/lexer/TokenizerOptions.ts
+++ b/src/lexer/TokenizerOptions.ts
@@ -49,8 +49,6 @@ export interface TokenizerOptions {
   reservedSelect: string[];
   // True to support XOR in addition to AND and OR
   supportsXor?: boolean;
-  // Keywords in CASE expressions that begin new line, like: WHEN, ELSE
-  reservedDependentClauses: string[];
   // Keywords that create newline but no indentaion of their body.
   // These contain set operations like UNION
   reservedSetOperations: string[];

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -17,6 +17,7 @@ export enum TokenType {
   END = 'END',
   WHEN = 'WHEN',
   ELSE = 'ELSE',
+  THEN = 'THEN',
   LIMIT = 'LIMIT',
   BETWEEN = 'BETWEEN',
   AND = 'AND',
@@ -92,6 +93,7 @@ export const isReserved = (type: TokenType): boolean =>
   type === TokenType.END ||
   type === TokenType.WHEN ||
   type === TokenType.ELSE ||
+  type === TokenType.THEN ||
   type === TokenType.LIMIT ||
   type === TokenType.BETWEEN ||
   type === TokenType.AND ||

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -7,7 +7,6 @@ export enum TokenType {
   RESERVED_KEYWORD = 'RESERVED_KEYWORD',
   RESERVED_FUNCTION_NAME = 'RESERVED_FUNCTION_NAME',
   RESERVED_PHRASE = 'RESERVED_PHRASE',
-  RESERVED_DEPENDENT_CLAUSE = 'RESERVED_DEPENDENT_CLAUSE',
   RESERVED_SET_OPERATION = 'RESERVED_SET_OPERATION',
   RESERVED_COMMAND = 'RESERVED_COMMAND',
   RESERVED_SELECT = 'RESERVED_SELECT',
@@ -16,6 +15,8 @@ export enum TokenType {
   ARRAY_KEYWORD = 'ARRAY_KEYWORD', // RESERVED_KEYWORD token in front of [
   CASE = 'CASE',
   END = 'END',
+  WHEN = 'WHEN',
+  ELSE = 'ELSE',
   LIMIT = 'LIMIT',
   BETWEEN = 'BETWEEN',
   AND = 'AND',
@@ -82,7 +83,6 @@ export const isReserved = (type: TokenType): boolean =>
   type === TokenType.RESERVED_KEYWORD ||
   type === TokenType.RESERVED_FUNCTION_NAME ||
   type === TokenType.RESERVED_PHRASE ||
-  type === TokenType.RESERVED_DEPENDENT_CLAUSE ||
   type === TokenType.RESERVED_COMMAND ||
   type === TokenType.RESERVED_SELECT ||
   type === TokenType.RESERVED_SET_OPERATION ||
@@ -90,6 +90,8 @@ export const isReserved = (type: TokenType): boolean =>
   type === TokenType.ARRAY_KEYWORD ||
   type === TokenType.CASE ||
   type === TokenType.END ||
+  type === TokenType.WHEN ||
+  type === TokenType.ELSE ||
   type === TokenType.LIMIT ||
   type === TokenType.BETWEEN ||
   type === TokenType.AND ||

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -234,10 +234,11 @@ literal ->
 keyword ->
   ( %RESERVED_KEYWORD
   | %RESERVED_PHRASE
-  | %RESERVED_DEPENDENT_CLAUSE
   | %RESERVED_JOIN
   | %CASE
   | %END
+  | %WHEN
+  | %ELSE
   | %AND
   | %OR
   | %XOR ) {%

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -239,6 +239,7 @@ keyword ->
   | %END
   | %WHEN
   | %ELSE
+  | %THEN
   | %AND
   | %OR
   | %XOR ) {%

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -118,8 +118,8 @@ export default function supportsCase(format: FormatFn) {
     expect(result).toBe(dedent`
       SELECT    CASE
                           foo
-                          WHEN      1 THEN bar
-                          ELSE      baz
+                          WHEN 1 THEN bar
+                          ELSE baz
                 END;
     `);
   });

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -123,4 +123,20 @@ export default function supportsCase(format: FormatFn) {
                 END;
     `);
   });
+
+  it('formats CASE with identStyle:tabularRight', () => {
+    const result = format('SELECT CASE foo WHEN 1 THEN bar ELSE baz END;', {
+      indentStyle: 'tabularRight',
+    });
+
+    expect(result).toBe(
+      [
+        '   SELECT CASE',
+        '                    foo',
+        '                    WHEN 1 THEN bar',
+        '                    ELSE baz',
+        '          END;',
+      ].join('\n')
+    );
+  });
 }

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -109,4 +109,18 @@ export default function supportsCase(format: FormatFn) {
         quaz
     `);
   });
+
+  it('formats CASE with identStyle:tabularLeft', () => {
+    const result = format('SELECT CASE foo WHEN 1 THEN bar ELSE baz END;', {
+      indentStyle: 'tabularLeft',
+    });
+
+    expect(result).toBe(dedent`
+      SELECT    CASE
+                          foo
+                          WHEN      1 THEN bar
+                          ELSE      baz
+                END;
+    `);
+  });
 }

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -6,7 +6,6 @@ describe('Parser', () => {
     const tokenizer = new Tokenizer({
       reservedCommands: ['FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
       reservedSelect: ['SELECT'],
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedSetOperations: ['UNION', 'UNION ALL'],
       reservedJoins: ['JOIN'],
       reservedFunctionNames: ['SQRT', 'CURRENT_TIME'],

--- a/test/unit/Tokenizer.test.ts
+++ b/test/unit/Tokenizer.test.ts
@@ -5,7 +5,6 @@ describe('Tokenizer', () => {
     new Tokenizer({
       reservedCommands: ['FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
       reservedSelect: ['SELECT'],
-      reservedDependentClauses: ['WHEN', 'ELSE'],
       reservedSetOperations: ['UNION', 'UNION ALL'],
       reservedJoins: ['JOIN'],
       reservedFunctionNames: ['SQRT', 'CURRENT_TIME'],


### PR DESCRIPTION
Eliminated `RESERVED_DEPENDENT_CLAUSE` token, which contained `WHEN` and `ELSE`, but also optionally `ELSEIF` and `ELSIF` - these two are actually never part of CASE expressions, so these keywords really don't belong here. There's now separate token types for `WHEN` and `ELSE` instead, while `ELSEIF` is part of ordinary keyword tokens.

Added tests for CASE expression formatting in tabular style, which was pretty messed up. Removed tabular styling from `WHEN` and `ELSE` tokens, which improved the formatting. Not yet ideal, but much better than before.

This whole change also paves road for properly parsing CASE expressions.

Fixes #401 (not ideally, but at least it's not as horrible as before).