### PR TITLE
Parse CASE expressions

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -185,20 +185,16 @@ export default class ExpressionFormatter {
   }
 
   private formatCaseWhen(node: CaseWhenNode) {
-    this.withComments(node.when, () => {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.when), WS.SPACE);
-    });
+    this.layout.add(WS.NEWLINE, WS.INDENT);
+    this.formatNode(node.when);
     this.layout = this.formatSubExpression(node.condition);
-    this.withComments(node.then, () => {
-      this.layout.add(this.showKw(node.then), WS.SPACE);
-    });
+    this.formatNode(node.then);
     this.layout = this.formatSubExpression(node.result);
   }
 
   private formatCaseElse(node: CaseElseNode) {
-    this.withComments(node.else, () => {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.else), WS.SPACE);
-    });
+    this.layout.add(WS.NEWLINE, WS.INDENT);
+    this.formatNode(node.else);
     this.layout = this.formatSubExpression(node.result);
   }
 

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -173,18 +173,15 @@ export default class ExpressionFormatter {
   }
 
   private formatCaseExpression(node: CaseExpressionNode) {
-    this.layout.indentation.increaseBlockLevel();
-    this.withComments(node.case, () => {
-      this.layout.add(this.showKw(node.case), WS.NEWLINE, WS.INDENT);
-    });
-
+    this.formatNode(node.case);
     this.layout = this.formatSubExpression(node.expr);
-    this.layout = this.formatSubExpression(node.clauses);
 
+    this.layout.indentation.increaseBlockLevel();
+    this.layout = this.formatSubExpression(node.clauses);
     this.layout.indentation.decreaseBlockLevel();
-    this.withComments(node.end, () => {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.end), WS.SPACE);
-    });
+
+    this.layout.add(WS.NEWLINE, WS.INDENT);
+    this.formatNode(node.end);
   }
 
   private formatCaseWhen(node: CaseWhenNode) {

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -396,12 +396,8 @@ export default class ExpressionFormatter {
       case TokenType.OR:
       case TokenType.XOR:
         return this.formatLogicalOperator(node);
-      case TokenType.RESERVED_KEYWORD:
-      case TokenType.RESERVED_FUNCTION_NAME:
-      case TokenType.RESERVED_PHRASE:
-        return this.formatKeyword(node);
       default:
-        throw new Error(`Unexpected token type: ${node.tokenType}`);
+        return this.formatKeyword(node);
     }
   }
 

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -9,6 +9,9 @@ export enum NodeType {
   property_access = 'property_access',
   parenthesis = 'parenthesis',
   between_predicate = 'between_predicate',
+  case_expression = 'case_expression',
+  case_when = 'case_when',
+  case_else = 'case_else',
   limit_clause = 'limit_clause',
   all_columns_asterisk = 'all_columns_asterisk',
   literal = 'literal',
@@ -71,6 +74,28 @@ export interface BetweenPredicateNode extends BaseNode {
   expr1: AstNode[];
   and: KeywordNode;
   expr2: AstNode[];
+}
+
+export interface CaseExpressionNode extends BaseNode {
+  type: NodeType.case_expression;
+  case: KeywordNode;
+  end: KeywordNode;
+  expr: AstNode[];
+  clauses: (CaseWhenNode | CaseElseNode)[];
+}
+
+export interface CaseWhenNode extends BaseNode {
+  type: NodeType.case_when;
+  when: KeywordNode;
+  then: KeywordNode;
+  condition: AstNode[];
+  result: AstNode[];
+}
+
+export interface CaseElseNode extends BaseNode {
+  type: NodeType.case_else;
+  else: KeywordNode;
+  result: AstNode[];
 }
 
 // LIMIT <count>
@@ -146,6 +171,9 @@ export type AstNode =
   | PropertyAccessNode
   | ParenthesisNode
   | BetweenPredicateNode
+  | CaseExpressionNode
+  | CaseWhenNode
+  | CaseElseNode
   | LimitClauseNode
   | AllColumnsAsteriskNode
   | LiteralNode

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -117,13 +117,7 @@ expression_with_comments -> simple_expression _ {%
   ([expr, _]) => addTrailingComments(expr, _)
 %}
 
-expression ->
-  ( simple_expression
-  | between_predicate
-  | case_expression
-  | comma
-  | comment
-  | other_keyword ) {% unwrap %}
+expression -> ( asteriskless_expression | asterisk ) {% unwrap %}
 
 asteriskless_expression ->
   ( simple_expression_without_asterisk

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -122,14 +122,16 @@ expression ->
   | between_predicate
   | case_expression
   | comma
-  | comment ) {% unwrap %}
+  | comment
+  | other_keyword ) {% unwrap %}
 
 asteriskless_expression ->
   ( simple_expression_without_asterisk
   | between_predicate
   | case_expression
   | comma
-  | comment ) {% unwrap %}
+  | comment
+  | other_keyword ) {% unwrap %}
 
 simple_expression -> ( simple_expression_without_asterisk | asterisk ) {% unwrap %}
 
@@ -275,6 +277,14 @@ keyword ->
   | %AND
   | %OR
   | %XOR ) {%
+  ([[token]]) => toKeywordNode(token)
+%}
+
+other_keyword ->
+  ( %WHEN
+  | %THEN
+  | %ELSE
+  | %END ) {%
   ([[token]]) => toKeywordNode(token)
 %}
 

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -117,9 +117,19 @@ expression_with_comments -> simple_expression _ {%
   ([expr, _]) => addTrailingComments(expr, _)
 %}
 
-expression -> ( simple_expression | between_predicate | comma | comment ) {% unwrap %}
+expression ->
+  ( simple_expression
+  | between_predicate
+  | case_expression
+  | comma
+  | comment ) {% unwrap %}
 
-asteriskless_expression -> ( simple_expression_without_asterisk | between_predicate | comma | comment ) {% unwrap %}
+asteriskless_expression ->
+  ( simple_expression_without_asterisk
+  | between_predicate
+  | case_expression
+  | comma
+  | comment ) {% unwrap %}
 
 simple_expression -> ( simple_expression_without_asterisk | asterisk ) {% unwrap %}
 
@@ -210,6 +220,33 @@ between_predicate -> %BETWEEN _ simple_expression _ %AND _ simple_expression {%
   })
 %}
 
+case_expression -> %CASE _ simple_expression:* case_clause:* _ %END {%
+  ([caseToken, _1, expr, clauses, _2, endToken]) => ({
+    type: NodeType.case_expression,
+    case: addTrailingComments(toKeywordNode(caseToken), _1),
+    end: addLeadingComments(toKeywordNode(endToken), _2),
+    expr,
+    clauses,
+  })
+%}
+
+case_clause -> _ %WHEN _ simple_expression:+ _ %THEN _ simple_expression:+ {%
+  ([_1, whenToken, _2, cond, _3, thenToken, _4, expr]) => ({
+    type: NodeType.case_when,
+    when: addTrailingComments(addLeadingComments(toKeywordNode(whenToken), _1), _2),
+    then: addTrailingComments(addLeadingComments(toKeywordNode(thenToken), _3), _4),
+    condition: cond,
+    result: expr,
+  })
+%}
+case_clause -> _ %ELSE _ simple_expression:+ {%
+  ([_1, elseToken, _2, expr]) => ({
+    type: NodeType.case_else,
+    else: addTrailingComments(addLeadingComments(toKeywordNode(elseToken), _1), _2),
+    result: expr,
+  })
+%}
+
 comma -> ( %COMMA ) {% ([[token]]) => ({ type: NodeType.comma }) %}
 
 asterisk -> ( %ASTERISK ) {% ([[token]]) => ({ type: NodeType.operator, text: token.text }) %}
@@ -235,11 +272,6 @@ keyword ->
   ( %RESERVED_KEYWORD
   | %RESERVED_PHRASE
   | %RESERVED_JOIN
-  | %CASE
-  | %END
-  | %WHEN
-  | %ELSE
-  | %THEN
   | %AND
   | %OR
   | %XOR ) {%

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -106,6 +106,36 @@ export default function supportsCase(format: FormatFn) {
     `);
   });
 
+  it('formats CASE with comments', () => {
+    const result = format(`
+      SELECT CASE /*c1*/ foo /*c2*/
+      WHEN /*c3*/ 1 /*c4*/ THEN /*c5*/ 2 /*c6*/
+      ELSE /*c7*/ 3 /*c8*/
+      END;
+    `);
+
+    expect(result).toBe(dedent`
+      SELECT
+        CASE
+        /*c1*/
+        foo
+          /*c2*/
+          WHEN
+          /*c3*/
+          1
+          /*c4*/
+          THEN
+          /*c5*/
+          2
+          /*c6*/
+          ELSE
+          /*c7*/
+          3
+        /*c8*/
+        END;
+    `);
+  });
+
   it('formats CASE with identStyle:tabularLeft', () => {
     const result = format('SELECT CASE foo WHEN 1 THEN bar ELSE baz END;', {
       indentStyle: 'tabularLeft',

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -24,8 +24,7 @@ export default function supportsCase(format: FormatFn) {
     );
 
     expect(result).toBe(dedent`
-      CASE
-        trim(sqrt(2))
+      CASE trim(sqrt(2))
         WHEN 'one' THEN 1
         WHEN 'two' THEN 2
         WHEN 'three' THEN 3
@@ -43,8 +42,7 @@ export default function supportsCase(format: FormatFn) {
       SELECT
         foo,
         bar,
-        CASE
-          baz
+        CASE baz
           WHEN 'one' THEN 1
           WHEN 'two' THEN 2
           ELSE 3
@@ -84,8 +82,7 @@ export default function supportsCase(format: FormatFn) {
       { keywordCase: 'upper' }
     );
     expect(result).toBe(dedent`
-      CASE
-        TRIM(SQRT(my_field))
+      CASE TRIM(SQRT(my_field))
         WHEN 'one' THEN 1
         WHEN 'two' THEN 2
         WHEN 'three' THEN 3
@@ -100,8 +97,7 @@ export default function supportsCase(format: FormatFn) {
     expect(result).toBe(dedent`
       select
         sum(
-          case
-            a
+          case a
             when foo then bar
           end
         )
@@ -116,8 +112,7 @@ export default function supportsCase(format: FormatFn) {
     });
 
     expect(result).toBe(dedent`
-      SELECT    CASE
-                          foo
+      SELECT    CASE foo
                           WHEN 1 THEN bar
                           ELSE baz
                 END;
@@ -131,8 +126,7 @@ export default function supportsCase(format: FormatFn) {
 
     expect(result).toBe(
       [
-        '   SELECT CASE',
-        '                    foo',
+        '   SELECT CASE foo',
         '                    WHEN 1 THEN bar',
         '                    ELSE baz',
         '          END;',

--- a/test/n1ql.test.ts
+++ b/test/n1ql.test.ts
@@ -118,8 +118,7 @@ describe('N1qlFormatter', () => {
       USE KEYS
         'Elinor_33313792'
       NEST
-        orders_with_users orders ON KEYS ARRAY s.order_id FOR s IN usr.shipped_order_history
-      END;
+        orders_with_users orders ON KEYS ARRAY s.order_id FOR s IN usr.shipped_order_history END;
     `);
   });
 

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -90,4 +90,8 @@ describe('Parser', () => {
   it('parses qualified.identifier.sequence', () => {
     expect(parse('SELECT foo.bar.baz;')).toMatchSnapshot();
   });
+
+  it('parses CASE expression', () => {
+    expect(parse('SELECT CASE foo WHEN 1+1 THEN 10 ELSE 20 END;')).toMatchSnapshot();
+  });
 });

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -53,6 +53,101 @@ Array [
 ]
 `;
 
+exports[`Parser parses CASE expression 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "case": Object {
+              "raw": "CASE",
+              "text": "CASE",
+              "tokenType": "CASE",
+              "type": "keyword",
+            },
+            "clauses": Array [
+              Object {
+                "condition": Array [
+                  Object {
+                    "text": "1",
+                    "type": "literal",
+                  },
+                  Object {
+                    "text": "+",
+                    "type": "operator",
+                  },
+                  Object {
+                    "text": "1",
+                    "type": "literal",
+                  },
+                ],
+                "result": Array [
+                  Object {
+                    "text": "10",
+                    "type": "literal",
+                  },
+                ],
+                "then": Object {
+                  "raw": "THEN",
+                  "text": "THEN",
+                  "tokenType": "THEN",
+                  "type": "keyword",
+                },
+                "type": "case_when",
+                "when": Object {
+                  "raw": "WHEN",
+                  "text": "WHEN",
+                  "tokenType": "WHEN",
+                  "type": "keyword",
+                },
+              },
+              Object {
+                "else": Object {
+                  "raw": "ELSE",
+                  "text": "ELSE",
+                  "tokenType": "ELSE",
+                  "type": "keyword",
+                },
+                "result": Array [
+                  Object {
+                    "text": "20",
+                    "type": "literal",
+                  },
+                ],
+                "type": "case_else",
+              },
+            ],
+            "end": Object {
+              "raw": "END",
+              "text": "END",
+              "tokenType": "END",
+              "type": "keyword",
+            },
+            "expr": Array [
+              Object {
+                "text": "foo",
+                "type": "identifier",
+              },
+            ],
+            "type": "case_expression",
+          },
+        ],
+        "name": Object {
+          "raw": "SELECT",
+          "text": "SELECT",
+          "tokenType": "RESERVED_SELECT",
+          "type": "keyword",
+        },
+        "type": "clause",
+      },
+    ],
+    "hasSemicolon": true,
+    "type": "statement",
+  },
+]
+`;
+
 exports[`Parser parses LIMIT clause with count 1`] = `
 Array [
   Object {


### PR DESCRIPTION
Implemented proper parsing of case expressions.

Also changed the formatting so that instead of:

```sql
CASE
  foo
  WHEN 1 THEN 'A'
  ELSE 'B'
END
```

we now format the expression following `CASE` on the same line:

```sql
CASE foo
  WHEN 1 THEN 'A'
  ELSE 'B'
END
```
