### PR TITLE
Adopt a consistent naming scheme for keyword-containing fields in AST

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -221,8 +221,8 @@ export default class ExpressionFormatter {
   }
 
   private formatLimitClause(node: LimitClauseNode) {
-    this.withComments(node.nameKw, () => {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.nameKw));
+    this.withComments(node.limitKw, () => {
+      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.limitKw));
     });
     this.layout.indentation.increaseTopLevel();
 

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -119,8 +119,8 @@ export default class ExpressionFormatter {
   }
 
   private formatFunctionCall(node: FunctionCallNode) {
-    this.withComments(node.name, () => {
-      this.layout.add(this.showKw(node.name));
+    this.withComments(node.nameKw, () => {
+      this.layout.add(this.showKw(node.nameKw));
     });
     this.formatNode(node.parenthesis);
   }
@@ -165,15 +165,15 @@ export default class ExpressionFormatter {
   }
 
   private formatBetweenPredicate(node: BetweenPredicateNode) {
-    this.layout.add(this.showKw(node.between), WS.SPACE);
+    this.layout.add(this.showKw(node.betweenKw), WS.SPACE);
     this.layout = this.formatSubExpression(node.expr1);
-    this.layout.add(WS.NO_SPACE, WS.SPACE, this.showNonTabularKw(node.and), WS.SPACE);
+    this.layout.add(WS.NO_SPACE, WS.SPACE, this.showNonTabularKw(node.andKw), WS.SPACE);
     this.layout = this.formatSubExpression(node.expr2);
     this.layout.add(WS.SPACE);
   }
 
   private formatCaseExpression(node: CaseExpressionNode) {
-    this.formatNode(node.case);
+    this.formatNode(node.caseKw);
     this.layout = this.formatSubExpression(node.expr);
 
     this.layout.indentation.increaseBlockLevel();
@@ -181,28 +181,28 @@ export default class ExpressionFormatter {
     this.layout.indentation.decreaseBlockLevel();
 
     this.layout.add(WS.NEWLINE, WS.INDENT);
-    this.formatNode(node.end);
+    this.formatNode(node.endKw);
   }
 
   private formatCaseWhen(node: CaseWhenNode) {
     this.layout.add(WS.NEWLINE, WS.INDENT);
-    this.formatNode(node.when);
+    this.formatNode(node.whenKw);
     this.layout = this.formatSubExpression(node.condition);
-    this.formatNode(node.then);
+    this.formatNode(node.thenKw);
     this.layout = this.formatSubExpression(node.result);
   }
 
   private formatCaseElse(node: CaseElseNode) {
     this.layout.add(WS.NEWLINE, WS.INDENT);
-    this.formatNode(node.else);
+    this.formatNode(node.elseKw);
     this.layout = this.formatSubExpression(node.result);
   }
 
   private formatClause(node: ClauseNode) {
     if (isTabularStyle(this.cfg)) {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.name), WS.SPACE);
+      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.nameKw), WS.SPACE);
     } else {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.name), WS.NEWLINE);
+      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.nameKw), WS.NEWLINE);
     }
     this.layout.indentation.increaseTopLevel();
 
@@ -215,14 +215,14 @@ export default class ExpressionFormatter {
   }
 
   private formatSetOperation(node: SetOperationNode) {
-    this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.name), WS.NEWLINE);
+    this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.nameKw), WS.NEWLINE);
     this.layout.add(WS.INDENT);
     this.layout = this.formatSubExpression(node.children);
   }
 
   private formatLimitClause(node: LimitClauseNode) {
-    this.withComments(node.name, () => {
-      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.name));
+    this.withComments(node.nameKw, () => {
+      this.layout.add(WS.NEWLINE, WS.INDENT, this.showKw(node.nameKw));
     });
     this.layout.indentation.increaseTopLevel();
 

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -37,19 +37,19 @@ export interface StatementNode extends BaseNode {
 
 export interface ClauseNode extends BaseNode {
   type: NodeType.clause;
-  name: KeywordNode;
+  nameKw: KeywordNode;
   children: AstNode[];
 }
 
 export interface SetOperationNode extends BaseNode {
   type: NodeType.set_operation;
-  name: KeywordNode;
+  nameKw: KeywordNode;
   children: AstNode[];
 }
 
 export interface FunctionCallNode extends BaseNode {
   type: NodeType.function_call;
-  name: KeywordNode;
+  nameKw: KeywordNode;
   parenthesis: ParenthesisNode;
 }
 
@@ -70,31 +70,31 @@ export interface ParenthesisNode extends BaseNode {
 // BETWEEN <expr1> AND <expr2>
 export interface BetweenPredicateNode extends BaseNode {
   type: NodeType.between_predicate;
-  between: KeywordNode;
+  betweenKw: KeywordNode;
   expr1: AstNode[];
-  and: KeywordNode;
+  andKw: KeywordNode;
   expr2: AstNode[];
 }
 
 export interface CaseExpressionNode extends BaseNode {
   type: NodeType.case_expression;
-  case: KeywordNode;
-  end: KeywordNode;
+  caseKw: KeywordNode;
+  endKw: KeywordNode;
   expr: AstNode[];
   clauses: (CaseWhenNode | CaseElseNode)[];
 }
 
 export interface CaseWhenNode extends BaseNode {
   type: NodeType.case_when;
-  when: KeywordNode;
-  then: KeywordNode;
+  whenKw: KeywordNode;
+  thenKw: KeywordNode;
   condition: AstNode[];
   result: AstNode[];
 }
 
 export interface CaseElseNode extends BaseNode {
   type: NodeType.case_else;
-  else: KeywordNode;
+  elseKw: KeywordNode;
   result: AstNode[];
 }
 
@@ -102,7 +102,7 @@ export interface CaseElseNode extends BaseNode {
 // LIMIT <offset>, <count>
 export interface LimitClauseNode extends BaseNode {
   type: NodeType.limit_clause;
-  name: KeywordNode;
+  nameKw: KeywordNode;
   count: AstNode[];
   offset?: AstNode[];
 }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -102,7 +102,7 @@ export interface CaseElseNode extends BaseNode {
 // LIMIT <offset>, <count>
 export interface LimitClauseNode extends BaseNode {
   type: NodeType.limit_clause;
-  nameKw: KeywordNode;
+  limitKw: KeywordNode;
   count: AstNode[];
   offset?: AstNode[];
 }

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -71,14 +71,14 @@ limit_clause -> %LIMIT _ expression_with_comments:+ (%COMMA expression:+):? {%
       const [comma, exp2] = optional;
       return {
         type: NodeType.limit_clause,
-        name: addTrailingComments(toKeywordNode(limitToken), _),
+        nameKw: addTrailingComments(toKeywordNode(limitToken), _),
         offset: exp1,
         count: exp2,
       };
     } else {
       return {
         type: NodeType.limit_clause,
-        name: addTrailingComments(toKeywordNode(limitToken), _),
+        nameKw: addTrailingComments(toKeywordNode(limitToken), _),
         count: exp1,
       };
     }
@@ -88,7 +88,7 @@ limit_clause -> %LIMIT _ expression_with_comments:+ (%COMMA expression:+):? {%
 select_clause -> %RESERVED_SELECT (all_columns_asterisk expression:* | asteriskless_expression expression:*) {%
   ([nameToken, [exp, expressions]]) => ({
     type: NodeType.clause,
-    name: toKeywordNode(nameToken),
+    nameKw: toKeywordNode(nameToken),
     children: [exp, ...expressions],
   })
 %}
@@ -100,7 +100,7 @@ all_columns_asterisk -> %ASTERISK {%
 other_clause -> %RESERVED_COMMAND expression:* {%
   ([nameToken, children]) => ({
     type: NodeType.clause,
-    name: toKeywordNode(nameToken),
+    nameKw: toKeywordNode(nameToken),
     children,
   })
 %}
@@ -108,7 +108,7 @@ other_clause -> %RESERVED_COMMAND expression:* {%
 set_operation -> %RESERVED_SET_OPERATION expression:* {%
   ([nameToken, children]) => ({
     type: NodeType.set_operation,
-    name: toKeywordNode(nameToken),
+    nameKw: toKeywordNode(nameToken),
     children,
   })
 %}
@@ -160,7 +160,7 @@ array_subscript -> %ARRAY_KEYWORD _ square_brackets {%
 function_call -> %RESERVED_FUNCTION_NAME _ parenthesis {%
   ([nameToken, _, parens]) => ({
     type: NodeType.function_call,
-    name: addTrailingComments(toKeywordNode(nameToken), _),
+    nameKw: addTrailingComments(toKeywordNode(nameToken), _),
     parenthesis: parens,
   })
 %}
@@ -209,9 +209,9 @@ property_access -> simple_expression _ %DOT _ (identifier | array_subscript | al
 between_predicate -> %BETWEEN _ simple_expression _ %AND _ simple_expression {%
   ([betweenToken, _1, expr1, _2, andToken, _3, expr2]) => ({
     type: NodeType.between_predicate,
-    between: toKeywordNode(betweenToken),
+    betweenKw: toKeywordNode(betweenToken),
     expr1: [addTrailingComments(addLeadingComments(expr1, _1), _2)],
-    and: toKeywordNode(andToken),
+    andKw: toKeywordNode(andToken),
     expr2: [addLeadingComments(expr2, _3)],
   })
 %}
@@ -219,8 +219,8 @@ between_predicate -> %BETWEEN _ simple_expression _ %AND _ simple_expression {%
 case_expression -> %CASE _ simple_expression:* case_clause:* _ %END {%
   ([caseToken, _1, expr, clauses, _2, endToken]) => ({
     type: NodeType.case_expression,
-    case: addTrailingComments(toKeywordNode(caseToken), _1),
-    end: addLeadingComments(toKeywordNode(endToken), _2),
+    caseKw: addTrailingComments(toKeywordNode(caseToken), _1),
+    endKw: addLeadingComments(toKeywordNode(endToken), _2),
     expr,
     clauses,
   })
@@ -229,8 +229,8 @@ case_expression -> %CASE _ simple_expression:* case_clause:* _ %END {%
 case_clause -> _ %WHEN _ simple_expression:+ _ %THEN _ simple_expression:+ {%
   ([_1, whenToken, _2, cond, _3, thenToken, _4, expr]) => ({
     type: NodeType.case_when,
-    when: addTrailingComments(addLeadingComments(toKeywordNode(whenToken), _1), _2),
-    then: addTrailingComments(addLeadingComments(toKeywordNode(thenToken), _3), _4),
+    whenKw: addTrailingComments(addLeadingComments(toKeywordNode(whenToken), _1), _2),
+    thenKw: addTrailingComments(addLeadingComments(toKeywordNode(thenToken), _3), _4),
     condition: cond,
     result: expr,
   })
@@ -238,7 +238,7 @@ case_clause -> _ %WHEN _ simple_expression:+ _ %THEN _ simple_expression:+ {%
 case_clause -> _ %ELSE _ simple_expression:+ {%
   ([_1, elseToken, _2, expr]) => ({
     type: NodeType.case_else,
-    else: addTrailingComments(addLeadingComments(toKeywordNode(elseToken), _1), _2),
+    elseKw: addTrailingComments(addLeadingComments(toKeywordNode(elseToken), _1), _2),
     result: expr,
   })
 %}

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -71,14 +71,14 @@ limit_clause -> %LIMIT _ expression_with_comments:+ (%COMMA expression:+):? {%
       const [comma, exp2] = optional;
       return {
         type: NodeType.limit_clause,
-        nameKw: addTrailingComments(toKeywordNode(limitToken), _),
+        limitKw: addTrailingComments(toKeywordNode(limitToken), _),
         offset: exp1,
         count: exp2,
       };
     } else {
       return {
         type: NodeType.limit_clause,
-        nameKw: addTrailingComments(toKeywordNode(limitToken), _),
+        limitKw: addTrailingComments(toKeywordNode(limitToken), _),
         count: exp1,
       };
     }

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -11,13 +11,13 @@ Array [
             "type": "identifier",
           },
           Object {
-            "and": Object {
+            "andKw": Object {
               "raw": "AND",
               "text": "AND",
               "tokenType": "AND",
               "type": "keyword",
             },
-            "between": Object {
+            "betweenKw": Object {
               "raw": "BETWEEN",
               "text": "BETWEEN",
               "tokenType": "BETWEEN",
@@ -38,7 +38,7 @@ Array [
             "type": "between_predicate",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "WHERE",
           "text": "WHERE",
           "tokenType": "RESERVED_COMMAND",
@@ -60,7 +60,7 @@ Array [
       Object {
         "children": Array [
           Object {
-            "case": Object {
+            "caseKw": Object {
               "raw": "CASE",
               "text": "CASE",
               "tokenType": "CASE",
@@ -88,14 +88,14 @@ Array [
                     "type": "literal",
                   },
                 ],
-                "then": Object {
+                "thenKw": Object {
                   "raw": "THEN",
                   "text": "THEN",
                   "tokenType": "THEN",
                   "type": "keyword",
                 },
                 "type": "case_when",
-                "when": Object {
+                "whenKw": Object {
                   "raw": "WHEN",
                   "text": "WHEN",
                   "tokenType": "WHEN",
@@ -103,7 +103,7 @@ Array [
                 },
               },
               Object {
-                "else": Object {
+                "elseKw": Object {
                   "raw": "ELSE",
                   "text": "ELSE",
                   "tokenType": "ELSE",
@@ -118,7 +118,7 @@ Array [
                 "type": "case_else",
               },
             ],
-            "end": Object {
+            "endKw": Object {
               "raw": "END",
               "text": "END",
               "tokenType": "END",
@@ -133,7 +133,7 @@ Array [
             "type": "case_expression",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -159,7 +159,7 @@ Array [
             "type": "literal",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "LIMIT",
           "text": "LIMIT",
           "tokenType": "LIMIT",
@@ -193,7 +193,7 @@ Array [
             "type": "literal",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "LIMIT",
           "text": "LIMIT",
           "tokenType": "LIMIT",
@@ -233,7 +233,7 @@ Array [
             "type": "literal",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "LIMIT",
           "text": "LIMIT",
           "tokenType": "LIMIT",
@@ -264,7 +264,7 @@ Array [
             "type": "all_columns_asterisk",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -296,7 +296,7 @@ Array [
             "type": "property_access",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -336,7 +336,7 @@ Array [
             "type": "array_subscript",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -382,7 +382,7 @@ Array [
             "type": "array_subscript",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -423,7 +423,7 @@ Array [
             "type": "parenthesis",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -445,7 +445,7 @@ Array [
       Object {
         "children": Array [
           Object {
-            "name": Object {
+            "nameKw": Object {
               "raw": "sqrt",
               "text": "SQRT",
               "tokenType": "RESERVED_FUNCTION_NAME",
@@ -465,7 +465,7 @@ Array [
             "type": "function_call",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -500,7 +500,7 @@ Array [
             "type": "comma",
           },
           Object {
-            "name": Object {
+            "nameKw": Object {
               "raw": "CURRENT_TIME",
               "text": "CURRENT_TIME",
               "tokenType": "RESERVED_FUNCTION_NAME",
@@ -519,7 +519,7 @@ Array [
             "type": "identifier",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -600,7 +600,7 @@ Array [
             "type": "parenthesis",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -640,7 +640,7 @@ Array [
             "type": "property_access",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -666,7 +666,7 @@ Array [
             "type": "identifier",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -681,7 +681,7 @@ Array [
             "type": "identifier",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "FROM",
           "text": "FROM",
           "tokenType": "RESERVED_COMMAND",
@@ -691,7 +691,7 @@ Array [
       },
       Object {
         "children": Array [],
-        "name": Object {
+        "nameKw": Object {
           "raw": "UNION ALL",
           "text": "UNION ALL",
           "tokenType": "RESERVED_SET_OPERATION",
@@ -706,7 +706,7 @@ Array [
             "type": "identifier",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",
@@ -721,7 +721,7 @@ Array [
             "type": "identifier",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "FROM",
           "text": "FROM",
           "tokenType": "RESERVED_COMMAND",
@@ -768,7 +768,7 @@ Array [
             "type": "parenthesis",
           },
         ],
-        "name": Object {
+        "nameKw": Object {
           "raw": "SELECT",
           "text": "SELECT",
           "tokenType": "RESERVED_SELECT",

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -159,7 +159,7 @@ Array [
             "type": "literal",
           },
         ],
-        "nameKw": Object {
+        "limitKw": Object {
           "raw": "LIMIT",
           "text": "LIMIT",
           "tokenType": "LIMIT",
@@ -193,7 +193,7 @@ Array [
             "type": "literal",
           },
         ],
-        "nameKw": Object {
+        "limitKw": Object {
           "raw": "LIMIT",
           "text": "LIMIT",
           "tokenType": "LIMIT",
@@ -233,7 +233,7 @@ Array [
             "type": "literal",
           },
         ],
-        "nameKw": Object {
+        "limitKw": Object {
           "raw": "LIMIT",
           "text": "LIMIT",
           "tokenType": "LIMIT",


### PR DESCRIPTION
Use -kw suffix for all single-keyword fields in AST