### PR TITLE
Allow comments inside CASE sub-expressions

### DIFF
--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -74,7 +74,7 @@ clause ->
   | other_clause
   | set_operation ) {% unwrap %}
 
-limit_clause -> %LIMIT _ expression_with_comments:+ (%COMMA free_form_sql:+):? {%
+limit_clause -> %LIMIT _ expression_chain (%COMMA free_form_sql:+):? {%
   ([limitToken, _, exp1, optional]) => {
     if (optional) {
       const [comma, exp2] = optional;
@@ -121,6 +121,8 @@ set_operation -> %RESERVED_SET_OPERATION free_form_sql:* {%
     children,
   })
 %}
+
+expression_chain -> expression_with_comments:+ {% id %}
 
 expression_with_comments -> expression _ {%
   ([expr, _]) => addComments(expr, { trailing: _ })

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -227,29 +227,29 @@ between_predicate -> %BETWEEN _ expression _ %AND _ expression {%
   })
 %}
 
-case_expression -> %CASE _ expression:* case_clause:* _ %END {%
-  ([caseToken, _1, expr, clauses, _2, endToken]) => ({
+case_expression -> %CASE _ expression_chain:? case_clause:* %END {%
+  ([caseToken, _, expr, clauses, endToken]) => ({
     type: NodeType.case_expression,
-    caseKw: addComments(toKeywordNode(caseToken), { trailing: _1 }),
-    endKw: addComments(toKeywordNode(endToken), { leading: _2 }),
-    expr,
+    caseKw: addComments(toKeywordNode(caseToken), { trailing: _ }),
+    endKw: toKeywordNode(endToken),
+    expr: expr || [],
     clauses,
   })
 %}
 
-case_clause -> _ %WHEN _ expression:+ _ %THEN _ expression:+ {%
-  ([_1, whenToken, _2, cond, _3, thenToken, _4, expr]) => ({
+case_clause -> %WHEN _ expression_chain %THEN _ expression_chain {%
+  ([whenToken, _1, cond, thenToken, _2, expr]) => ({
     type: NodeType.case_when,
-    whenKw: addComments(toKeywordNode(whenToken), { leading: _1, trailing: _2 }),
-    thenKw: addComments(toKeywordNode(thenToken), { leading: _3, trailing: _4 }),
+    whenKw: addComments(toKeywordNode(whenToken), { trailing: _1 }),
+    thenKw: addComments(toKeywordNode(thenToken), { trailing: _2 }),
     condition: cond,
     result: expr,
   })
 %}
-case_clause -> _ %ELSE _ expression:+ {%
-  ([_1, elseToken, _2, expr]) => ({
+case_clause -> %ELSE _ expression_chain {%
+  ([elseToken, _, expr]) => ({
     type: NodeType.case_else,
-    elseKw: addComments(toKeywordNode(elseToken), { leading: _1, trailing: _2 }),
+    elseKw: addComments(toKeywordNode(elseToken), { trailing: _ }),
     result: expr,
   })
 %}

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -116,10 +116,27 @@ export default function supportsCase(format: FormatFn) {
 
     expect(result).toBe(dedent`
       SELECT
-        CASE /*c1*/ foo
-          /*c2*/ WHEN /*c3*/ 1 /*c4*/ THEN /*c5*/ 2
-          /*c6*/ ELSE /*c7*/ 3
-        /*c8*/ END;
+        CASE /*c1*/ foo /*c2*/
+          WHEN /*c3*/ 1 /*c4*/ THEN /*c5*/ 2 /*c6*/
+          ELSE /*c7*/ 3 /*c8*/
+        END;
+    `);
+  });
+
+  it('formats CASE with comments inside sub-expressions', () => {
+    const result = format(`
+      SELECT CASE foo + /*c1*/ bar
+      WHEN 1 /*c2*/ + 1 THEN 2 /*c2*/ * 2
+      ELSE 3 - /*c3*/ 3
+      END;
+    `);
+
+    expect(result).toBe(dedent`
+      SELECT
+        CASE foo + /*c1*/ bar
+          WHEN 1 /*c2*/ + 1 THEN 2 /*c2*/ * 2
+          ELSE 3 - /*c3*/ 3
+        END;
     `);
   });
 


### PR DESCRIPTION
Forgot about more complex expressions also containing comments when first implementing CASE expression parsing #459