### PR TITLE
Add dialect-specific format options

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -36,14 +36,21 @@ import InlineLayout, { InlineLayoutError } from './InlineLayout';
 
 interface ExpressionFormatterParams {
   cfg: FormatOptions;
+  dialectCfg: DialectFormatOptions;
   params: Params;
   layout: Layout;
   inline?: boolean;
 }
 
+export interface DialectFormatOptions {
+  // True to format "foo@bar" without spaces around @-operator
+  denseAtOperator?: boolean;
+}
+
 /** Formats a generic SQL expression */
 export default class ExpressionFormatter {
   private cfg: FormatOptions;
+  private dialectCfg: DialectFormatOptions;
   private params: Params;
   private layout: Layout;
 
@@ -51,8 +58,9 @@ export default class ExpressionFormatter {
   private nodes: AstNode[] = [];
   private index = -1;
 
-  constructor({ cfg, params, layout, inline = false }: ExpressionFormatterParams) {
+  constructor({ cfg, dialectCfg, params, layout, inline = false }: ExpressionFormatterParams) {
     this.cfg = cfg;
+    this.dialectCfg = dialectCfg;
     this.inline = inline;
     this.params = params;
     this.layout = layout;
@@ -268,7 +276,7 @@ export default class ExpressionFormatter {
       return;
     }
     // special case for PLSQL @ dblink syntax
-    else if (text === '@' && this.cfg.language === 'plsql') {
+    else if (text === '@' && this.dialectCfg.denseAtOperator) {
       this.layout.add(WS.NO_SPACE, text);
       return;
     }
@@ -351,6 +359,7 @@ export default class ExpressionFormatter {
   private formatSubExpression(nodes: AstNode[]): Layout {
     return new ExpressionFormatter({
       cfg: this.cfg,
+      dialectCfg: this.dialectCfg,
       params: this.params,
       layout: this.layout,
       inline: this.inline,
@@ -362,6 +371,7 @@ export default class ExpressionFormatter {
     try {
       return new ExpressionFormatter({
         cfg: this.cfg,
+        dialectCfg: this.dialectCfg,
         params: this.params,
         layout: new InlineLayout(this.cfg.expressionWidth),
         inline: true,

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -43,8 +43,8 @@ interface ExpressionFormatterParams {
 }
 
 export interface DialectFormatOptions {
-  // True to format "foo@bar" without spaces around @-operator
-  denseAtOperator?: boolean;
+  // List of operators that should always be formatted without surrounding spaces
+  alwaysDenseOperators?: string[];
 }
 
 /** Formats a generic SQL expression */
@@ -275,14 +275,9 @@ export default class ExpressionFormatter {
       this.layout.add(WS.NO_SPACE, text);
       return;
     }
-    // special case for PLSQL @ dblink syntax
-    else if (text === '@' && this.dialectCfg.denseAtOperator) {
-      this.layout.add(WS.NO_SPACE, text);
-      return;
-    }
 
     // other operators
-    if (this.cfg.denseOperators) {
+    if (this.cfg.denseOperators || this.dialectCfg.alwaysDenseOperators?.includes(text)) {
       this.layout.add(WS.NO_SPACE, text);
     } else {
       this.layout.add(text, WS.SPACE);

--- a/src/formatter/Formatter.ts
+++ b/src/formatter/Formatter.ts
@@ -8,7 +8,7 @@ import { StatementNode } from 'src/parser/ast';
 
 import formatCommaPositions from './formatCommaPositions';
 import formatAliasPositions from './formatAliasPositions';
-import ExpressionFormatter from './ExpressionFormatter';
+import ExpressionFormatter, { DialectFormatOptions } from './ExpressionFormatter';
 import Layout, { WS } from './Layout';
 import Indentation from './Indentation';
 
@@ -41,6 +41,13 @@ export default class Formatter {
   }
 
   /**
+   * Dialect-specific formatting configuration, optionally provided by subclass.
+   */
+  protected formatOptions(): DialectFormatOptions {
+    return {};
+  }
+
+  /**
    * Formats an SQL query.
    * @param {string} query - The SQL query string to be formatted
    * @return {string} The formatter query
@@ -66,6 +73,7 @@ export default class Formatter {
   private formatStatement(statement: StatementNode): string {
     const layout = new ExpressionFormatter({
       cfg: this.cfg,
+      dialectCfg: this.formatOptions(),
       params: this.params,
       layout: new Layout(new Indentation(indentString(this.cfg))),
     }).format(statement.children);

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -1,5 +1,6 @@
 import { expandPhrases } from 'src/expandPhrases';
 import Formatter from 'src/formatter/Formatter';
+import { DialectFormatOptions } from 'src/formatter/ExpressionFormatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { EOF_TOKEN, isReserved, isToken, Token, TokenType } from 'src/lexer/token';
 import { keywords } from './plsql.keywords';
@@ -118,8 +119,8 @@ export default class PlSqlFormatter extends Formatter {
     });
   }
 
-  formatOptions() {
-    return { denseAtOperator: true };
+  formatOptions(): DialectFormatOptions {
+    return { alwaysDenseOperators: ['@'] };
   }
 }
 

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -117,6 +117,10 @@ export default class PlSqlFormatter extends Formatter {
       postProcess,
     });
   }
+
+  formatOptions() {
+    return { denseAtOperator: true };
+  }
 }
 
 function postProcess(tokens: Token[]) {


### PR DESCRIPTION
Instead of checking if `language === 'plsql'` the PL/SQL language definition now provides an options object with `{alwaysDenseOperators: ['@']}` which is used instead. This decouples the formatting logic from any specific language name.

Implementing what I suggested in here: #455