### PR TITLE
Add file with .js extension for use by unpkg.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Format whitespace in a SQL query to make it more readable",
   "license": "MIT",
   "main": "dist/sql-formatter.min.cjs",
+  "unpkg": "dist/sql-formatter.min.js",
   "module": "lib/index.js",
   "types": "lib/src/index.d.ts",
   "exports": {
@@ -101,7 +102,7 @@
     "grammar": "nearleyc src/parser/grammar.ne -o src/parser/grammar.ts",
     "build:babel": "babel src --out-dir lib --extensions .ts --source-maps",
     "build:types": "ttsc --module commonjs --emitDeclarationOnly --isolatedModules",
-    "build:minified": "webpack --config webpack.prod.js",
+    "build:minified": "webpack --config webpack.prod.js && cp dist/sql-formatter.min.cjs dist/sql-formatter.min.js",
     "build": "yarn grammar && npm-run-all --parallel build:babel build:types build:minified",
     "release": "release-it"
   },


### PR DESCRIPTION
The `.cjs` extension doesn't work well with unpkg.com, which serves this file as `text/plain`, which in turn results in javascript not being able to execute.

Added quick fix by creating a copy of the file with `.js` extension and declaring a separate path for the unpkg to use. 