### PR TITLE
Escape special regex chars in keyword lists

### DIFF
--- a/src/lexer/regexFactory.ts
+++ b/src/lexer/regexFactory.ts
@@ -45,6 +45,7 @@ export const reservedWord = (reservedKeywords: string[], identChars: IdentChars 
   const avoidIdentChars = rejectIdentCharsPattern(identChars);
 
   const reservedKeywordsPattern = sortByLengthDesc(reservedKeywords)
+    .map(escapeRegExp)
     .join('|')
     .replace(/ /gu, '\\s+');
 


### PR DESCRIPTION
Another small tweak to aid with implementation of Snowflake dialect.