### PR TITLE
Target Node 14.x in ESM build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,5 +12,8 @@
       }
     ],
     ["babel-plugin-inline-import", { "extensions": [".sql"] }]
-  ]
+  ],
+  "targets": {
+    "node": 14
+  }
 }


### PR DESCRIPTION
Changing our build to output ES modules changed the build results in odd way. The `require()` syntax was replaced by `import`, but all other moders ECMAScript was still compiled to the lowest possible version. For example, this sum() function:

```ts
export const sum = (arr: number[]): number => {
  let total = 0;
  for (const x of arr) {
    total += x;
  }
  return total;
};
```

was compiled to:

```js
export var sum = function sum(arr) {
  var total = 0;

  var _iterator = _createForOfIteratorHelper(arr),
      _step;

  try {
    for (_iterator.s(); !(_step = _iterator.n()).done;) {
      var x = _step.value;
      total += x;
    }
  } catch (err) {
    _iterator.e(err);
  } finally {
    _iterator.f();
  }

  return total;
};
```

But clearly, any JS environment that recognizes export/import syntax can also handle const, arrow functions and many other things. Switching the build target to Node 14.x, now produces the following much better result

```js
export const sum = arr => {
  let total = 0;

  for (const x of arr) {
    total += x;
  }

  return total;
};
```