### PR TITLE
Make alwaysDenseOperators config to also work with :: and : operators

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -271,9 +271,6 @@ export default class ExpressionFormatter {
     if (text === ':') {
       this.layout.add(WS.NO_SPACE, text, WS.SPACE);
       return;
-    } else if (text === '::') {
-      this.layout.add(WS.NO_SPACE, text);
-      return;
     }
 
     // other operators

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -267,15 +267,10 @@ export default class ExpressionFormatter {
   }
 
   private formatOperator({ text }: OperatorNode) {
-    // special operator
-    if (text === ':') {
-      this.layout.add(WS.NO_SPACE, text, WS.SPACE);
-      return;
-    }
-
-    // other operators
     if (this.cfg.denseOperators || this.dialectCfg.alwaysDenseOperators?.includes(text)) {
       this.layout.add(WS.NO_SPACE, text);
+    } else if (text === ':') {
+      this.layout.add(WS.NO_SPACE, text, WS.SPACE);
     } else {
       this.layout.add(text, WS.SPACE);
     }

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -1,4 +1,5 @@
 import { expandPhrases } from 'src/expandPhrases';
+import { DialectFormatOptions } from 'src/formatter/ExpressionFormatter';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './postgresql.functions';
@@ -354,5 +355,9 @@ export default class PostgreSqlFormatter extends Formatter {
         '::',
       ],
     });
+  }
+
+  formatOptions(): DialectFormatOptions {
+    return { alwaysDenseOperators: ['::'] };
   }
 }

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -1,4 +1,5 @@
 import { expandPhrases } from 'src/expandPhrases';
+import { DialectFormatOptions } from 'src/formatter/ExpressionFormatter';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './redshift.functions';
@@ -169,5 +170,9 @@ export default class RedshiftFormatter extends Formatter {
         '::',
       ],
     });
+  }
+
+  formatOptions(): DialectFormatOptions {
+    return { alwaysDenseOperators: ['::'] };
   }
 }

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -1,4 +1,5 @@
 import { expandPhrases } from 'src/expandPhrases';
+import { DialectFormatOptions } from 'src/formatter/ExpressionFormatter';
 import Formatter from 'src/formatter/Formatter';
 import Tokenizer from 'src/lexer/Tokenizer';
 import { functions } from './transactsql.functions';
@@ -248,5 +249,9 @@ export default class TransactSqlFormatter extends Formatter {
       ],
       // TODO: Support for money constants
     });
+  }
+
+  formatOptions(): DialectFormatOptions {
+    return { alwaysDenseOperators: ['::'] };
   }
 }


### PR DESCRIPTION
Additionally the user-configured `denseOperators` config now also applies to `:` operator.