### PR TITLE
Improve ON DELETE/ON UPDATE constraints formatting

### DIFF
--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -166,7 +166,12 @@ const reservedJoins = expandPhrases([
   '{INNER | CROSS} JOIN',
 ]);
 
-const reservedPhrases = expandPhrases(['ON DELETE', 'ON UPDATE', '{ROWS | RANGE} BETWEEN']);
+const reservedPhrases = expandPhrases([
+  'ON DELETE',
+  'ON UPDATE',
+  'SET NULL',
+  '{ROWS | RANGE} BETWEEN',
+]);
 
 // https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_72/db2/rbafzintro.htm
 export default class Db2Formatter extends Formatter {

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -254,8 +254,7 @@ const reservedJoins = expandPhrases([
 ]);
 
 const reservedPhrases = expandPhrases([
-  'ON DELETE',
-  'ON UPDATE',
+  'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
   'CHARACTER SET',
   '{ROWS | RANGE} BETWEEN',
 ]);

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -222,8 +222,7 @@ const reservedJoins = expandPhrases([
 ]);
 
 const reservedPhrases = expandPhrases([
-  'ON DELETE',
-  'ON UPDATE',
+  'ON {UPDATE | DELETE} [SET NULL]',
   'CHARACTER SET',
   '{ROWS | RANGE} BETWEEN',
 ]);

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -73,8 +73,7 @@ const reservedJoins = expandPhrases([
 ]);
 
 const reservedPhrases = expandPhrases([
-  'ON DELETE',
-  'ON UPDATE',
+  'ON {UPDATE | DELETE} [SET NULL]',
   'ON COMMIT',
   '{ROWS | RANGE} BETWEEN',
 ]);

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -239,8 +239,7 @@ const reservedJoins = expandPhrases([
 ]);
 
 const reservedPhrases = expandPhrases([
-  'ON DELETE',
-  'ON UPDATE',
+  'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
   '{ROWS | RANGE | GROUPS} BETWEEN',
   // https://www.postgresql.org/docs/current/datatype-datetime.html
   '{TIMESTAMP | TIME} {WITH | WITHOUT} TIME ZONE',

--- a/src/languages/snowflake/snowflake.formatter.ts
+++ b/src/languages/snowflake/snowflake.formatter.ts
@@ -310,9 +310,7 @@ const reservedJoins = expandPhrases([
 
 const reservedPhrases = expandPhrases([
   '{ROWS | RANGE} BETWEEN',
-  'MATCH {FULL | SIMPLE | PARTIAL}',
-  'ON {UPDATE | DELETE} {CASCADE | SET NULL | SET DEFAULT | RESTRICT | NO ACTION}',
-  'INITIALLY {DEFERRED | IMMEDIATE}',
+  'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
 ]);
 
 export default class SnowflakeFormatter extends Formatter {

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -65,7 +65,10 @@ const reservedJoins = expandPhrases([
   'NATURAL {LEFT | RIGHT | FULL} [OUTER] JOIN',
 ]);
 
-const reservedPhrases = expandPhrases(['ON DELETE', 'ON UPDATE', '{ROWS | RANGE} BETWEEN']);
+const reservedPhrases = expandPhrases([
+  'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
+  '{ROWS | RANGE} BETWEEN',
+]);
 
 export default class SqlFormatter extends Formatter {
   tokenizer() {

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -55,8 +55,7 @@ const reservedJoins = expandPhrases([
 ]);
 
 const reservedPhrases = expandPhrases([
-  'ON DELETE',
-  'ON UPDATE',
+  'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
   '{ROWS | RANGE | GROUPS} BETWEEN',
 ]);
 

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -211,7 +211,10 @@ const reservedJoins = expandPhrases([
   '{CROSS | OUTER} APPLY',
 ]);
 
-const reservedPhrases = expandPhrases(['ON DELETE', 'ON UPDATE', '{ROWS | RANGE} BETWEEN']);
+const reservedPhrases = expandPhrases([
+  'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
+  '{ROWS | RANGE} BETWEEN',
+]);
 
 // https://docs.microsoft.com/en-us/sql/t-sql/language-reference?view=sql-server-ver15
 export default class TransactSqlFormatter extends Formatter {

--- a/test/behavesLikeMariaDbFormatter.ts
+++ b/test/behavesLikeMariaDbFormatter.ts
@@ -5,7 +5,6 @@ import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
 
 import supportsDropTable from './features/dropTable';
 import supportsBetween from './features/between';
-import supportsConstraints from './features/constraints';
 import supportsDeleteFrom from './features/deleteFrom';
 import supportsComments from './features/comments';
 import supportsStrings from './features/strings';
@@ -23,7 +22,6 @@ export default function behavesLikeMariaDbFormatter(format: FormatFn) {
   supportsStrings(format, ["''-qq", "''-bs", '""-qq', '""-bs', "X''"]);
   supportsIdentifiers(format, ['``']);
   supportsDropTable(format, { ifExists: true });
-  supportsConstraints(format);
   supportsDeleteFrom(format);
   supportsInsertInto(format, { withoutInto: true });
   supportsUpdate(format);

--- a/test/db2.test.ts
+++ b/test/db2.test.ts
@@ -33,7 +33,7 @@ describe('Db2Formatter', () => {
   supportsCreateView(format, { orReplace: true });
   supportsCreateTable(format);
   supportsDropTable(format);
-  supportsConstraints(format);
+  supportsConstraints(format, ['NO ACTION', 'RESTRICT', 'CASCADE', 'SET NULL']);
   supportsAlterTable(format, {
     addColumn: true,
     dropColumn: true,

--- a/test/features/constraints.ts
+++ b/test/features/constraints.ts
@@ -2,9 +2,7 @@ import dedent from 'dedent-js';
 
 import { FormatFn } from 'src/sqlFormatter';
 
-const standardActions = ['CURRENT_TIMESTAMP'];
-
-export default function supportsConstraints(format: FormatFn, actions: string[] = standardActions) {
+export default function supportsConstraints(format: FormatFn, actions: string[]) {
   actions.forEach(action => {
     it(`treats ON UPDATE & ON DELETE ${action} as distinct keywords from ON`, () => {
       expect(

--- a/test/mariadb.test.ts
+++ b/test/mariadb.test.ts
@@ -13,6 +13,7 @@ import supportsParams from './options/param';
 import supportsCreateView from './features/createView';
 import supportsAlterTable from './features/alterTable';
 import supportsStrings from './features/strings';
+import supportsConstraints from './features/constraints';
 
 describe('MariaDbFormatter', () => {
   const language = 'mariadb';
@@ -36,6 +37,7 @@ describe('MariaDbFormatter', () => {
   supportsReturning(format);
   supportsLimiting(format, { limit: true, offset: true, fetchFirst: true, fetchNext: true });
   supportsCreateTable(format, { orReplace: true, ifNotExists: true });
+  supportsConstraints(format, ['RESTRICT', 'CASCADE', 'SET NULL', 'NO ACTION', 'SET DEFAULT']);
   supportsParams(format, { positional: true });
   supportsCreateView(format, { orReplace: true });
   supportsAlterTable(format, {

--- a/test/mysql.test.ts
+++ b/test/mysql.test.ts
@@ -13,6 +13,7 @@ import supportsParams from './options/param';
 import supportsCreateView from './features/createView';
 import supportsAlterTable from './features/alterTable';
 import supportsStrings from './features/strings';
+import supportsConstraints from './features/constraints';
 
 describe('MySqlFormatter', () => {
   const language = 'mysql';
@@ -36,6 +37,14 @@ describe('MySqlFormatter', () => {
   supportsWindow(format);
   supportsLimiting(format, { limit: true, offset: true });
   supportsCreateTable(format, { ifNotExists: true });
+  supportsConstraints(format, [
+    'RESTRICT',
+    'CASCADE',
+    'SET NULL',
+    'NO ACTION',
+    'NOW',
+    'CURRENT_TIMESTAMP',
+  ]);
   supportsParams(format, { positional: true });
   supportsCreateView(format, { orReplace: true });
   supportsAlterTable(format, {

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -34,7 +34,8 @@ describe('PlSqlFormatter', () => {
   supportsCreateView(format, { orReplace: true, materialized: true });
   supportsCreateTable(format);
   supportsDropTable(format);
-  supportsConstraints(format);
+  // http://dba-oracle.com/bk_on_delete_restrict_on_delete_no_action_tips.htm
+  supportsConstraints(format, ['SET NULL', 'CASCADE', 'NO ACTION']);
   supportsAlterTable(format, {
     dropColumn: true,
     modify: true,

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -35,7 +35,7 @@ describe('PostgreSqlFormatter', () => {
   supportsCreateView(format, { orReplace: true, materialized: true });
   supportsCreateTable(format, { ifNotExists: true });
   supportsDropTable(format, { ifExists: true });
-  supportsConstraints(format);
+  supportsConstraints(format, ['NO ACTION', 'RESTRICT', 'CASCADE', 'SET NULL', 'SET DEFAULT']);
   supportsArrayAndMapAccessors(format);
   supportsAlterTable(format, {
     addColumn: true,

--- a/test/snowflake.test.ts
+++ b/test/snowflake.test.ts
@@ -30,6 +30,7 @@ describe('SnowflakeFormatter', () => {
   supportsComments(format, { doubleSlashComments: true });
   supportsCreateView(format, { orReplace: true, ifNotExists: true });
   supportsCreateTable(format, { orReplace: true, ifNotExists: true });
+  supportsConstraints(format, ['CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION']);
   supportsDropTable(format, { ifExists: true });
   supportsArrayAndMapAccessors(format);
   supportsAlterTable(format, {
@@ -50,7 +51,6 @@ describe('SnowflakeFormatter', () => {
   supportsJoin(format, { without: ['NATURAL INNER JOIN'] });
   supportsSetOperations(format, ['UNION', 'UNION ALL', 'MINUS', 'EXCEPT', 'INTERSECT']);
   supportsLimiting(format, { limit: true, offset: true, fetchFirst: true, fetchNext: true });
-  supportsConstraints(format, ['CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION']);
 
   it('allows $ character as part of unquoted identifiers', () => {
     expect(format('SELECT foo$')).toBe(dedent`

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -33,7 +33,7 @@ describe('SqlFormatter', () => {
   supportsCreateView(format);
   supportsCreateTable(format);
   supportsDropTable(format);
-  supportsConstraints(format);
+  supportsConstraints(format, ['CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION']);
   supportsAlterTable(format, {
     addColumn: true,
     dropColumn: true,

--- a/test/sqlite.test.ts
+++ b/test/sqlite.test.ts
@@ -31,7 +31,7 @@ describe('SqliteFormatter', () => {
   supportsCreateView(format);
   supportsCreateTable(format, { ifNotExists: true });
   supportsDropTable(format, { ifExists: true });
-  supportsConstraints(format);
+  supportsConstraints(format, ['SET NULL', 'SET DEFAULT', 'CASCADE', 'RESTRICT', 'NO ACTION']);
   supportsAlterTable(format, {
     addColumn: true,
     dropColumn: true,

--- a/test/transactsql.test.ts
+++ b/test/transactsql.test.ts
@@ -33,7 +33,7 @@ describe('TransactSqlFormatter', () => {
   supportsCreateView(format, { materialized: true });
   supportsCreateTable(format);
   supportsDropTable(format, { ifExists: true });
-  supportsConstraints(format);
+  supportsConstraints(format, ['SET NULL', 'SET DEFAULT', 'CASCADE', 'NO ACTION']);
   supportsAlterTable(format, {
     dropColumn: true,
   });


### PR DESCRIPTION
This problem surfaced in Snowflake implementation.

Refactored all constraints tests and fixed problems with formatting of `SET NULL` & `SET DEFAULT` (when they follow `ON UPDATE` or `ON DELETE`). The formatting of which will be different when they occur in e.g. `ALTER TABLE foo ALTER COLUMN col SET DEFAULT 3`.