### PR TITLE
Replace "command" terminology with "clause"

### DIFF
--- a/src/formatter/Indentation.ts
+++ b/src/formatter/Indentation.ts
@@ -9,7 +9,7 @@ const INDENT_TYPE_BLOCK_LEVEL = 'block-level';
  * There are two types of indentation levels:
  *
  * - BLOCK_LEVEL : increased by open-parenthesis
- * - TOP_LEVEL : increased by RESERVED_COMMAND words
+ * - TOP_LEVEL : increased by RESERVED_CLAUSE words
  */
 export default class Indentation {
   private indentTypes: string[] = [];

--- a/src/formatter/tabularStyle.ts
+++ b/src/formatter/tabularStyle.ts
@@ -31,7 +31,7 @@ export default function toTabularFormat(tokenText: string, indentStyle: IndentSt
 export function isTabularToken(type: TokenType): boolean {
   return (
     isLogicalOperator(type) ||
-    type === TokenType.RESERVED_COMMAND ||
+    type === TokenType.RESERVED_CLAUSE ||
     type === TokenType.RESERVED_SELECT ||
     type === TokenType.RESERVED_SET_OPERATION ||
     type === TokenType.RESERVED_JOIN ||

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -7,7 +7,7 @@ import { functions } from './bigquery.functions';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT] [AS STRUCT | AS VALUE]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // Queries: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
   'WITH [RECURSIVE]',
   'FROM',
@@ -143,7 +143,7 @@ export default class BigQueryFormatter extends Formatter {
   // TODO: handle trailing comma in select clause
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -175,7 +175,7 @@ function postProcess(tokens: Token[]): Token[] {
   return detectArraySubscripts(combineParameterizedTypes(tokens));
 }
 
-// Converts OFFSET token inside array from RESERVED_COMMAND to RESERVED_FUNCTION_NAME
+// Converts OFFSET token inside array from RESERVED_CLAUSE to RESERVED_FUNCTION_NAME
 // See: https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#array_subscript_operator
 function detectArraySubscripts(tokens: Token[]) {
   let prevToken = EOF_TOKEN;

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -6,7 +6,7 @@ import { keywords } from './db2.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH',
   'FROM',
@@ -177,7 +177,7 @@ const reservedPhrases = expandPhrases([
 export default class Db2Formatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -6,7 +6,7 @@ import { keywords } from './hive.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH',
   'FROM',
@@ -84,7 +84,7 @@ const reservedPhrases = expandPhrases(['{ROWS | RANGE} BETWEEN']);
 export default class HiveFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -7,7 +7,7 @@ import { functions } from './mariadb.functions';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT | DISTINCTROW]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -263,7 +263,7 @@ const reservedPhrases = expandPhrases([
 export default class MariaDbFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -7,7 +7,7 @@ import { functions } from './mysql.functions';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT | DISTINCTROW]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -231,7 +231,7 @@ const reservedPhrases = expandPhrases([
 export default class MySqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -6,7 +6,7 @@ import { keywords } from './n1ql.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH',
   'FROM',
@@ -81,7 +81,7 @@ const reservedPhrases = expandPhrases(['{ROWS | RANGE | GROUPS} BETWEEN']);
 export default class N1qlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -8,7 +8,7 @@ import { functions } from './plsql.functions';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT | UNIQUE]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH',
   'FROM',
@@ -81,7 +81,7 @@ const reservedPhrases = expandPhrases([
 export default class PlSqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -7,7 +7,7 @@ import { keywords } from './postgresql.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -249,7 +249,7 @@ const reservedPhrases = expandPhrases([
 export default class PostgreSqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -7,7 +7,7 @@ import { keywords } from './redshift.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -143,7 +143,7 @@ const reservedPhrases = expandPhrases([
 export default class RedshiftFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -7,7 +7,7 @@ import { functions } from './singlestoredb.functions';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT | DISTINCTROW]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH',
   'FROM',
@@ -233,7 +233,7 @@ const reservedPhrases = expandPhrases([
 export default class SingleStoreDbFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/snowflake/snowflake.formatter.ts
+++ b/src/languages/snowflake/snowflake.formatter.ts
@@ -18,7 +18,7 @@ const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 // Steps 1-4 can be combined by the following script in the developer console:
 // $x('//tbody/tr/*[1]//a/span/text()').map(x => x.nodeValue) // Step 1
 //   filter(x => !x.match(/\(.*\)/) && !x.match(/…/) && !x.match(/<.*>/)) // Step 2-4
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -315,7 +315,7 @@ const reservedPhrases = expandPhrases([
 export default class SnowflakeFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -8,7 +8,7 @@ import { functions } from './spark.functions';
 // http://spark.apache.org/docs/latest/sql-ref-syntax.html
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH',
   'FROM',
@@ -119,7 +119,7 @@ const reservedPhrases = expandPhrases([
 export default class SparkFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -6,7 +6,7 @@ import { keywords } from './sql.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -73,7 +73,7 @@ const reservedPhrases = expandPhrases([
 export default class SqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -6,7 +6,7 @@ import { keywords } from './sqlite.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -62,7 +62,7 @@ const reservedPhrases = expandPhrases([
 export default class SqliteFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -7,7 +7,7 @@ import { keywords } from './transactsql.keywords';
 
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH',
   'FROM',
@@ -220,7 +220,7 @@ const reservedPhrases = expandPhrases([
 export default class TransactSqlFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -7,7 +7,7 @@ import { keywords } from './trino.keywords';
 const reservedSelect = expandPhrases(['SELECT [ALL | DISTINCT]']);
 
 // https://github.com/trinodb/trino/blob/432d2897bdef99388c1a47188743a061c4ac1f34/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4#L41
-const reservedCommands = expandPhrases([
+const reservedClauses = expandPhrases([
   // queries
   'WITH [RECURSIVE]',
   'FROM',
@@ -122,7 +122,7 @@ const reservedPhrases = expandPhrases(['{ROWS | RANGE | GROUPS} BETWEEN']);
 export default class TrinoFormatter extends Formatter {
   tokenizer() {
     return new Tokenizer({
-      reservedCommands,
+      reservedClauses,
       reservedSelect,
       reservedSetOperations,
       reservedJoins,

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -49,7 +49,7 @@ export default class Tokenizer {
           /(?:0x[0-9a-fA-F]+|0b[01]+|(?:-\s*)?[0-9]+(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+(?:\.[0-9]+)?)?)(?!\w)/uy,
       },
       // RESERVED_PHRASE is matched before all other keyword tokens
-      // to e.g. prioritize matching "TIMESTAMP WITH TIME ZONE" phrase over "WITH" command.
+      // to e.g. prioritize matching "TIMESTAMP WITH TIME ZONE" phrase over "WITH" clause.
       {
         type: TokenType.RESERVED_PHRASE,
         regex: regex.reservedWord(cfg.reservedPhrases ?? [], cfg.identChars),

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -72,12 +72,12 @@ export default class Tokenizer {
       },
       {
         type: TokenType.LIMIT,
-        regex: cfg.reservedCommands.includes('LIMIT') ? /LIMIT\b/iuy : undefined,
+        regex: cfg.reservedClauses.includes('LIMIT') ? /LIMIT\b/iuy : undefined,
         text: toCanonical,
       },
       {
         type: TokenType.RESERVED_COMMAND,
-        regex: regex.reservedWord(cfg.reservedCommands, cfg.identChars),
+        regex: regex.reservedWord(cfg.reservedClauses, cfg.identChars),
         text: toCanonical,
       },
       {

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -76,7 +76,7 @@ export default class Tokenizer {
         text: toCanonical,
       },
       {
-        type: TokenType.RESERVED_COMMAND,
+        type: TokenType.RESERVED_CLAUSE,
         regex: regex.reservedWord(cfg.reservedClauses, cfg.identChars),
         text: toCanonical,
       },

--- a/src/lexer/TokenizerOptions.ts
+++ b/src/lexer/TokenizerOptions.ts
@@ -44,7 +44,7 @@ export interface ParamTypes {
 
 export interface TokenizerOptions {
   // Main clauses that start new block, like: WITH, FROM, WHERE, ORDER BY
-  reservedCommands: string[];
+  reservedClauses: string[];
   // SELECT clause and its variations
   reservedSelect: string[];
   // True to support XOR in addition to AND and OR

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -8,7 +8,7 @@ export enum TokenType {
   RESERVED_FUNCTION_NAME = 'RESERVED_FUNCTION_NAME',
   RESERVED_PHRASE = 'RESERVED_PHRASE',
   RESERVED_SET_OPERATION = 'RESERVED_SET_OPERATION',
-  RESERVED_COMMAND = 'RESERVED_COMMAND',
+  RESERVED_CLAUSE = 'RESERVED_CLAUSE',
   RESERVED_SELECT = 'RESERVED_SELECT',
   RESERVED_JOIN = 'RESERVED_JOIN',
   ARRAY_IDENTIFIER = 'ARRAY_IDENTIFIER', // IDENTIFIER token in front of [
@@ -74,9 +74,9 @@ export const testToken =
 export const isToken = {
   ARRAY: testToken({ text: 'ARRAY', type: TokenType.RESERVED_KEYWORD }),
   BY: testToken({ text: 'BY', type: TokenType.RESERVED_KEYWORD }),
-  SET: testToken({ text: 'SET', type: TokenType.RESERVED_COMMAND }),
+  SET: testToken({ text: 'SET', type: TokenType.RESERVED_CLAUSE }),
   STRUCT: testToken({ text: 'STRUCT', type: TokenType.RESERVED_KEYWORD }),
-  WINDOW: testToken({ text: 'WINDOW', type: TokenType.RESERVED_COMMAND }),
+  WINDOW: testToken({ text: 'WINDOW', type: TokenType.RESERVED_CLAUSE }),
 };
 
 /** Checks if token is any Reserved Keyword or Command */
@@ -84,7 +84,7 @@ export const isReserved = (type: TokenType): boolean =>
   type === TokenType.RESERVED_KEYWORD ||
   type === TokenType.RESERVED_FUNCTION_NAME ||
   type === TokenType.RESERVED_PHRASE ||
-  type === TokenType.RESERVED_COMMAND ||
+  type === TokenType.RESERVED_CLAUSE ||
   type === TokenType.RESERVED_SELECT ||
   type === TokenType.RESERVED_SET_OPERATION ||
   type === TokenType.RESERVED_JOIN ||

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -79,7 +79,7 @@ export const isToken = {
   WINDOW: testToken({ text: 'WINDOW', type: TokenType.RESERVED_CLAUSE }),
 };
 
-/** Checks if token is any Reserved Keyword or Command */
+/** Checks if token is any Reserved Keyword or Clause */
 export const isReserved = (type: TokenType): boolean =>
   type === TokenType.RESERVED_KEYWORD ||
   type === TokenType.RESERVED_FUNCTION_NAME ||

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -119,7 +119,7 @@ all_columns_asterisk -> %ASTERISK {%
   () => ({ type: NodeType.all_columns_asterisk })
 %}
 
-other_clause -> %RESERVED_COMMAND free_form_sql:* {%
+other_clause -> %RESERVED_CLAUSE free_form_sql:* {%
   ([nameToken, children]) => ({
     type: NodeType.clause,
     nameKw: toKeywordNode(nameToken),

--- a/test/options/indentStyle.ts
+++ b/test/options/indentStyle.ts
@@ -36,7 +36,7 @@ export default function supportsIndentStyle(format: FormatFn) {
   });
 
   describe('indentStyle: tabularLeft', () => {
-    it('aligns command keywords to left', () => {
+    it('aligns clause keywords to left', () => {
       const result = format(baseQuery, { indentStyle: 'tabularLeft' });
       expect(result).toBe(dedent`
         SELECT    COUNT(a.column1),
@@ -154,7 +154,7 @@ export default function supportsIndentStyle(format: FormatFn) {
   });
 
   describe('indentStyle: tabularRight', () => {
-    it('aligns command keywords to right', () => {
+    it('aligns clause keywords to right', () => {
       const result = format(baseQuery, { indentStyle: 'tabularRight' });
       expect(result).toBe(
         [

--- a/test/options/keywordCase.ts
+++ b/test/options/keywordCase.ts
@@ -63,7 +63,7 @@ export default function supportsKeywordCase(format: FormatFn) {
   });
 
   // regression test for #356
-  it('formats multi-word reserved commands into single line', () => {
+  it('formats multi-word reserved clauses into single line', () => {
     const result = format(
       `select * from mytable
       inner

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -4,7 +4,7 @@ import { createParser } from 'src/parser/createParser';
 describe('Parser', () => {
   const parse = (sql: string) => {
     const tokenizer = new Tokenizer({
-      reservedCommands: ['FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
+      reservedClauses: ['FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
       reservedSelect: ['SELECT'],
       reservedSetOperations: ['UNION', 'UNION ALL'],
       reservedJoins: ['JOIN'],

--- a/test/unit/Tokenizer.test.ts
+++ b/test/unit/Tokenizer.test.ts
@@ -3,7 +3,7 @@ import Tokenizer from 'src/lexer/Tokenizer';
 describe('Tokenizer', () => {
   const tokenize = (sql: string) =>
     new Tokenizer({
-      reservedCommands: ['FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
+      reservedClauses: ['FROM', 'WHERE', 'LIMIT', 'CREATE TABLE'],
       reservedSelect: ['SELECT'],
       reservedSetOperations: ['UNION', 'UNION ALL'],
       reservedJoins: ['JOIN'],

--- a/test/unit/__snapshots__/Parser.test.ts.snap
+++ b/test/unit/__snapshots__/Parser.test.ts.snap
@@ -41,7 +41,7 @@ Array [
         "nameKw": Object {
           "raw": "WHERE",
           "text": "WHERE",
-          "tokenType": "RESERVED_COMMAND",
+          "tokenType": "RESERVED_CLAUSE",
           "type": "keyword",
         },
         "type": "clause",
@@ -685,7 +685,7 @@ Array [
         "nameKw": Object {
           "raw": "FROM",
           "text": "FROM",
-          "tokenType": "RESERVED_COMMAND",
+          "tokenType": "RESERVED_CLAUSE",
           "type": "keyword",
         },
         "type": "clause",
@@ -725,7 +725,7 @@ Array [
         "nameKw": Object {
           "raw": "FROM",
           "text": "FROM",
-          "tokenType": "RESERVED_COMMAND",
+          "tokenType": "RESERVED_CLAUSE",
           "type": "keyword",
         },
         "type": "clause",

--- a/test/unit/__snapshots__/Tokenizer.test.ts.snap
+++ b/test/unit/__snapshots__/Tokenizer.test.ts.snap
@@ -62,7 +62,7 @@ Array [
     "raw": "FROM",
     "start": 9,
     "text": "FROM",
-    "type": "RESERVED_COMMAND",
+    "type": "RESERVED_CLAUSE",
   },
   Object {
     "precedingWhitespace": " ",


### PR DESCRIPTION
For consistency with terminology already used in AST.

So, instead of `RESERVED_COMMAND` token beginning a `ClauseNode` we now have `RESERVED_CLAUSE` token.