### PR TITLE
Export language-specific format functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,23 @@
-export * from './sqlFormatter';
+export {
+  format,
+  formatBigQuery,
+  formatDb2,
+  formatHive,
+  formatMariaDb,
+  formatMySql,
+  formatN1ql,
+  formatPlSql,
+  formatPostgreSql,
+  formatRedshift,
+  formatSpark,
+  formatSqlite,
+  formatStandardSQL,
+  formatTrino,
+  formatTransactSql,
+  formatSingleStoreDb,
+  formatSnowflake,
+} from './sqlFormatter';
+export type { SqlLanguage, FormatFn } from './sqlFormatter';
 export type {
   IndentStyle,
   KeywordCase,

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -62,9 +62,13 @@ const defaultOptions: FormatOptions = {
  * @param {FormatOptions} cfg Configuration options (see docs in README)
  * @return {string} formatted query
  */
-export const format = (query: string, cfg: Partial<FormatOptions> = {}): string => {
+export const format = (query: string, cfg: Partial<FormatOptions> = defaultOptions): string => {
   if (typeof query !== 'string') {
     throw new Error('Invalid query argument. Expected string, instead got ' + typeof query);
+  }
+
+  if (typeof cfg.language === 'string' && !supportedDialects.includes(cfg.language)) {
+    throw new ConfigError(`Unsupported SQL dialect: ${cfg.language}`);
   }
 
   const options = validateConfig({
@@ -80,11 +84,7 @@ export const format = (query: string, cfg: Partial<FormatOptions> = {}): string 
 
 export class ConfigError extends Error {}
 
-function validateConfig(cfg: FormatOptions): FormatOptions {
-  if (typeof cfg.language === 'string' && !supportedDialects.includes(cfg.language)) {
-    throw new ConfigError(`Unsupported SQL dialect: ${cfg.language}`);
-  }
-
+const validateConfig = (cfg: FormatOptions): FormatOptions => {
   if ('multilineLists' in cfg) {
     throw new ConfigError('multilineLists config is no more supported.');
   }
@@ -116,11 +116,11 @@ function validateConfig(cfg: FormatOptions): FormatOptions {
   }
 
   return cfg;
-}
+};
 
-function validateParams(params: ParamItems | string[]): boolean {
+const validateParams = (params: ParamItems | string[]): boolean => {
   const paramValues = params instanceof Array ? params : Object.values(params);
   return paramValues.every(p => typeof p === 'string');
-}
+};
 
 export type FormatFn = typeof format;

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -16,7 +16,7 @@ import SingleStoreDbFormatter from './languages/singlestoredb/singlestoredb.form
 import SnowflakeFormatter from './languages/snowflake/snowflake.formatter';
 
 import { FormatOptions } from './FormatOptions';
-import { ParamItems } from './formatter/Params';
+import { ConfigError, validateConfig, validateQuery } from './validateConfigs';
 
 export const formatters = {
   bigquery: BigQueryFormatter,
@@ -63,9 +63,7 @@ const defaultOptions: FormatOptions = {
  * @return {string} formatted query
  */
 export const format = (query: string, cfg: Partial<FormatOptions> = defaultOptions): string => {
-  if (typeof query !== 'string') {
-    throw new Error('Invalid query argument. Expected string, instead got ' + typeof query);
-  }
+  validateQuery(query);
 
   if (typeof cfg.language === 'string' && !supportedDialects.includes(cfg.language)) {
     throw new ConfigError(`Unsupported SQL dialect: ${cfg.language}`);
@@ -80,47 +78,6 @@ export const format = (query: string, cfg: Partial<FormatOptions> = defaultOptio
     typeof options.language === 'string' ? formatters[options.language] : options.language;
 
   return new FormatterCls(options).format(query);
-};
-
-export class ConfigError extends Error {}
-
-const validateConfig = (cfg: FormatOptions): FormatOptions => {
-  if ('multilineLists' in cfg) {
-    throw new ConfigError('multilineLists config is no more supported.');
-  }
-  if ('newlineBeforeOpenParen' in cfg) {
-    throw new ConfigError('newlineBeforeOpenParen config is no more supported.');
-  }
-  if ('newlineBeforeCloseParen' in cfg) {
-    throw new ConfigError('newlineBeforeCloseParen config is no more supported.');
-  }
-  if ('aliasAs' in cfg) {
-    throw new ConfigError('aliasAs config is no more supported.');
-  }
-
-  if (cfg.expressionWidth <= 0) {
-    throw new ConfigError(
-      `expressionWidth config must be positive number. Received ${cfg.expressionWidth} instead.`
-    );
-  }
-
-  if (cfg.commaPosition === 'before' && cfg.useTabs) {
-    throw new ConfigError(
-      'commaPosition: before does not work when tabs are used for indentation.'
-    );
-  }
-
-  if (cfg.params && !validateParams(cfg.params)) {
-    // eslint-disable-next-line no-console
-    console.warn('WARNING: All "params" option values should be strings.');
-  }
-
-  return cfg;
-};
-
-const validateParams = (params: ParamItems | string[]): boolean => {
-  const paramValues = params instanceof Array ? params : Object.values(params);
-  return paramValues.every(p => typeof p === 'string');
 };
 
 export type FormatFn = typeof format;

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -80,4 +80,16 @@ export const format = (query: string, cfg: Partial<FormatOptions> = defaultOptio
   return new FormatterCls(options).format(query);
 };
 
+export const formatStandardSQL: FormatFn = (
+  query: string,
+  cfg: Partial<Exclude<FormatOptions, 'language'>> = {}
+): string => {
+  validateQuery(query);
+  const options = validateConfig({
+    ...defaultOptions,
+    ...cfg,
+  });
+  return new SqlFormatter(options).format(query);
+};
+
 export type FormatFn = typeof format;

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -19,7 +19,7 @@ import Formatter from './formatter/Formatter';
 import { FormatOptions } from './FormatOptions';
 import { ConfigError, validateConfig, validateQuery } from './validateConfigs';
 
-export const formatters = {
+const formatters = {
   bigquery: BigQueryFormatter,
   db2: Db2Formatter,
   hive: HiveFormatter,

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -15,6 +15,7 @@ import TransactSqlFormatter from 'src/languages/transactsql/transactsql.formatte
 import SingleStoreDbFormatter from './languages/singlestoredb/singlestoredb.formatter';
 import SnowflakeFormatter from './languages/snowflake/snowflake.formatter';
 
+import Formatter from './formatter/Formatter';
 import { FormatOptions } from './FormatOptions';
 import { ConfigError, validateConfig, validateQuery } from './validateConfigs';
 
@@ -80,16 +81,32 @@ export const format = (query: string, cfg: Partial<FormatOptions> = defaultOptio
   return new FormatterCls(options).format(query);
 };
 
-export const formatStandardSQL: FormatFn = (
-  query: string,
-  cfg: Partial<Exclude<FormatOptions, 'language'>> = {}
-): string => {
-  validateQuery(query);
-  const options = validateConfig({
-    ...defaultOptions,
-    ...cfg,
-  });
-  return new SqlFormatter(options).format(query);
-};
+const languageFormat =
+  <Lang extends typeof Formatter>(FormatterCls: Lang) =>
+  (query: string, cfg: Partial<Exclude<FormatOptions, 'language'>> = {}) => {
+    validateQuery(query);
+    const options = validateConfig({
+      ...defaultOptions,
+      ...cfg,
+    });
+    return new FormatterCls(options).format(query);
+  };
 
 export type FormatFn = typeof format;
+
+export const formatBigQuery: FormatFn = languageFormat(BigQueryFormatter);
+export const formatDb2: FormatFn = languageFormat(Db2Formatter);
+export const formatHive: FormatFn = languageFormat(HiveFormatter);
+export const formatMariaDb: FormatFn = languageFormat(MariaDbFormatter);
+export const formatMySql: FormatFn = languageFormat(MySqlFormatter);
+export const formatN1ql: FormatFn = languageFormat(N1qlFormatter);
+export const formatPlSql: FormatFn = languageFormat(PlSqlFormatter);
+export const formatPostgreSql: FormatFn = languageFormat(PostgreSqlFormatter);
+export const formatRedshift: FormatFn = languageFormat(RedshiftFormatter);
+export const formatSpark: FormatFn = languageFormat(SparkFormatter);
+export const formatSqlite: FormatFn = languageFormat(SqliteFormatter);
+export const formatStandardSQL: FormatFn = languageFormat(SqlFormatter);
+export const formatTrino: FormatFn = languageFormat(TrinoFormatter);
+export const formatTransactSql: FormatFn = languageFormat(TransactSqlFormatter);
+export const formatSingleStoreDb: FormatFn = languageFormat(SingleStoreDbFormatter);
+export const formatSnowflake: FormatFn = languageFormat(SnowflakeFormatter);

--- a/src/validateConfigs.ts
+++ b/src/validateConfigs.ts
@@ -1,0 +1,49 @@
+import { FormatOptions } from './FormatOptions';
+import { ParamItems } from './formatter/Params';
+
+export class ConfigError extends Error {}
+
+export const validateQuery = (query: string) => {
+  if (typeof query !== 'string') {
+    throw new Error('Invalid query argument. Expected string, instead got ' + typeof query);
+  }
+};
+
+export const validateConfig = (cfg: FormatOptions): FormatOptions => {
+  if ('multilineLists' in cfg) {
+    throw new ConfigError('multilineLists config is no more supported.');
+  }
+  if ('newlineBeforeOpenParen' in cfg) {
+    throw new ConfigError('newlineBeforeOpenParen config is no more supported.');
+  }
+  if ('newlineBeforeCloseParen' in cfg) {
+    throw new ConfigError('newlineBeforeCloseParen config is no more supported.');
+  }
+  if ('aliasAs' in cfg) {
+    throw new ConfigError('aliasAs config is no more supported.');
+  }
+
+  if (cfg.expressionWidth <= 0) {
+    throw new ConfigError(
+      `expressionWidth config must be positive number. Received ${cfg.expressionWidth} instead.`
+    );
+  }
+
+  if (cfg.commaPosition === 'before' && cfg.useTabs) {
+    throw new ConfigError(
+      'commaPosition: before does not work when tabs are used for indentation.'
+    );
+  }
+
+  if (cfg.params && !validateParams(cfg.params)) {
+    // eslint-disable-next-line no-console
+    console.warn('WARNING: All "params" option values should be strings.');
+  }
+
+  return cfg;
+};
+
+const validateParams = (params: ParamItems | string[]): boolean => {
+  const paramValues = params instanceof Array ? params : Object.values(params);
+  return paramValues.every(p => typeof p === 'string');
+};


### PR DESCRIPTION
- moved Format config validation to separate file
- curried language-specific format functions
- update index to export only specific members