### PR TITLE
Drop excessive tests for BigQuery syntax variants

### DIFF
--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -306,45 +306,6 @@ describe('BigQueryFormatter', () => {
       expect(format(input)).toBe(expected);
     });
 
-    it(`Supports CREATE TABLE LIKE`, () => {
-      const input = `
-        CREATE TABLE mydataset.newtable
-        LIKE mydataset.sourcetable
-        AS (SELECT * FROM mydataset.myothertable)`;
-      const expected = dedent`
-        CREATE TABLE
-          mydataset.newtable LIKE mydataset.sourcetable AS (
-            SELECT
-              *
-            FROM
-              mydataset.myothertable
-          )`;
-
-      expect(format(input)).toBe(expected);
-    });
-
-    it(`Supports CREATE TABLE COPY`, () => {
-      const input = `
-        CREATE TABLE mydataset.newtable
-        COPY mydataset.sourcetable`;
-      const expected = dedent`
-        CREATE TABLE
-          mydataset.newtable COPY mydataset.sourcetable`;
-
-      expect(format(input)).toBe(expected);
-    });
-
-    it(`Supports CREATE TABLE CLONE`, () => {
-      const input = `
-        CREATE TABLE mydataset.newtable
-        CLONE mydataset.sourcetable`;
-      const expected = dedent`
-        CREATE TABLE
-          mydataset.newtable CLONE mydataset.sourcetable`;
-
-      expect(format(input)).toBe(expected);
-    });
-
     it(`Supports CREATE EXTERNAL TABLE ... WITH PARTITION COLUMN`, () => {
       const input = `
         CREATE EXTERNAL TABLE dataset.CsvTable

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -591,22 +591,6 @@ describe('BigQueryFormatter', () => {
       });
     });
 
-    it(`Supports DROP SCHEMA - CASCADE`, () => {
-      const input = `
-        DROP SCHEMA mydataset CASCADE`;
-      const expected = dedent`
-        DROP SCHEMA mydataset CASCADE`;
-      expect(format(input)).toBe(expected);
-    });
-
-    it(`Supports DROP SCHEMA - RESTRICT`, () => {
-      const input = `
-        DROP SCHEMA mydataset RESTRICT`;
-      const expected = dedent`
-        DROP SCHEMA mydataset RESTRICT`;
-      expect(format(input)).toBe(expected);
-    });
-
     it(`Supports DROP SEARCH INDEX`, () => {
       const input = `
         DROP SEARCH INDEX index2 ON mydataset.mytable`;

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -200,25 +200,15 @@ describe('BigQueryFormatter', () => {
   });
 
   it('supports parameterised types', () => {
-    const result = format(
-      `
-      DECLARE varString STRING(11) '11charswide';
-      DECLARE varBytes BYTES(8);
-      DECLARE varNumeric NUMERIC(1,1);
-      DECLARE varDecimal DECIMAL(1,1);
-      DECLARE varBignumeric BIGNUMERIC(1,1);
-      DECLARE varBigdecimal BIGDECIMAL(1,1);
-    `,
-      { linesBetweenQueries: 0 }
-    );
-    expect(result).toBe(dedent`
+    const sql = dedent`
       DECLARE varString STRING(11) '11charswide';
       DECLARE varBytes BYTES(8);
       DECLARE varNumeric NUMERIC(1, 1);
       DECLARE varDecimal DECIMAL(1, 1);
       DECLARE varBignumeric BIGNUMERIC(1, 1);
       DECLARE varBigdecimal BIGDECIMAL(1, 1);
-    `);
+    `;
+    expect(format(sql, { linesBetweenQueries: 0 })).toBe(sql);
   });
 
   // Regression test for issue #243

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -566,26 +566,17 @@ describe('BigQueryFormatter', () => {
     it(`Supports DROP clauses`, () => {
       const input = dedent`
         DROP SCHEMA mydataset.name;
-
         DROP VIEW mydataset.name;
-
         DROP FUNCTION mydataset.name;
-
         DROP TABLE FUNCTION mydataset.name;
-
         DROP PROCEDURE mydataset.name;
-
         DROP RESERVATION mydataset.name;
-
         DROP ASSIGNMENT mydataset.name;
-
         DROP SEARCH INDEX index2 ON mydataset.mytable;
-
         DROP mypolicy ON mydataset.mytable;
-
         DROP ALL ROW ACCESS POLICIES ON table_name;
       `;
-      expect(format(input)).toBe(input);
+      expect(format(input, { linesBetweenQueries: 0 })).toBe(input);
     });
   });
 });

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -573,46 +573,29 @@ describe('BigQueryFormatter', () => {
   });
 
   describe('BigQuery DDL Drop Statements', () => {
-    [
-      'DROP SCHEMA',
-      'DROP VIEW',
-      'DROP FUNCTION',
-      'DROP TABLE FUNCTION',
-      'DROP PROCEDURE',
-      'DROP RESERVATION',
-      'DROP ASSIGNMENT',
-    ].forEach(drop => {
-      it(`Supports ${drop}`, () => {
-        const input = `
-          ${drop} mydataset.name`;
-        const expected = dedent`
-          ${drop} mydataset.name`;
-        expect(format(input)).toBe(expected);
-      });
-    });
+    it(`Supports DROP clauses`, () => {
+      const input = dedent`
+        DROP SCHEMA mydataset.name;
 
-    it(`Supports DROP SEARCH INDEX`, () => {
-      const input = `
-        DROP SEARCH INDEX index2 ON mydataset.mytable`;
-      const expected = dedent`
-        DROP SEARCH INDEX index2 ON mydataset.mytable`;
-      expect(format(input)).toBe(expected);
-    });
+        DROP VIEW mydataset.name;
 
-    it(`Supports DROP ROW ACCESS POLICY`, () => {
-      const input = `
-        DROP mypolicy ON mydataset.mytable`;
-      const expected = dedent`
-        DROP mypolicy ON mydataset.mytable`;
-      expect(format(input)).toBe(expected);
-    });
+        DROP FUNCTION mydataset.name;
 
-    it(`Supports DROP ALL ROW ACCESS POLICIES`, () => {
-      const input = `
-        DROP ALL ROW ACCESS POLICIES ON table_name`;
-      const expected = dedent`
-        DROP ALL ROW ACCESS POLICIES ON table_name`;
-      expect(format(input)).toBe(expected);
+        DROP TABLE FUNCTION mydataset.name;
+
+        DROP PROCEDURE mydataset.name;
+
+        DROP RESERVATION mydataset.name;
+
+        DROP ASSIGNMENT mydataset.name;
+
+        DROP SEARCH INDEX index2 ON mydataset.mytable;
+
+        DROP mypolicy ON mydataset.mytable;
+
+        DROP ALL ROW ACCESS POLICIES ON table_name;
+      `;
+      expect(format(input)).toBe(input);
     });
   });
 });

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -407,50 +407,27 @@ describe('BigQueryFormatter', () => {
       expect(format(input)).toBe(expected);
     });
 
-    it(`Supports CREATE CAPACITY`, () => {
-      const input = dedent`
-        CREATE CAPACITY admin_project.region-us.my-commitment
-        AS JSON """{
-            "slot_count": 100,
-            "plan": "FLEX"
-          }"""`;
-      const expected = dedent`
-        CREATE CAPACITY admin_project.region-us.my-commitment
-        AS JSON """{
-            "slot_count": 100,
-            "plan": "FLEX"
-          }"""`;
-      expect(format(input)).toBe(expected);
-    });
-
-    it(`Supports CREATE RESERVATION`, () => {
-      const input = dedent`
-        CREATE RESERVATION admin_project.region-us.prod
-        AS JSON """{
-            "slot_capacity": 100
-          }"""`;
-      const expected = dedent`
-        CREATE RESERVATION admin_project.region-us.prod
-        AS JSON """{
-            "slot_capacity": 100
-          }"""`;
-      expect(format(input)).toBe(expected);
-    });
-
-    it(`Supports CREATE ASSIGNMENT`, () => {
-      const input = dedent`
-        CREATE ASSIGNMENT admin_project.region-us.prod.my_assignment
-        AS JSON """{
-            "assignee": "projects/my_project",
-            "job_type": "QUERY"
-          }"""`;
-      const expected = dedent`
-        CREATE ASSIGNMENT admin_project.region-us.prod.my_assignment
-        AS JSON """{
-            "assignee": "projects/my_project",
-            "job_type": "QUERY"
-          }"""`;
-      expect(format(input)).toBe(expected);
+    [
+      // Create statements using "AS JSON"
+      'CREATE CAPACITY',
+      'CREATE RESERVATION',
+      'CREATE ASSIGNMENT',
+    ].forEach(create => {
+      it(`Supports ${create}`, () => {
+        const input = dedent`
+          ${create} admin_project.region-us.my-commitment
+          AS JSON """{
+              "slot_count": 100,
+              "plan": "FLEX"
+            }"""`;
+        const expected = dedent`
+          ${create} admin_project.region-us.my-commitment
+          AS JSON """{
+              "slot_count": 100,
+              "plan": "FLEX"
+            }"""`;
+        expect(format(input)).toBe(expected);
+      });
     });
 
     it(`Supports CREATE SEARCH INDEX`, () => {

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -607,14 +607,6 @@ describe('BigQueryFormatter', () => {
       expect(format(input)).toBe(expected);
     });
 
-    it(`Supports DROP ROW ACCESS POLICY IF EXISTS`, () => {
-      const input = `
-        DROP IF EXISTS mypolicy ON mydataset.mytable`;
-      const expected = dedent`
-        DROP IF EXISTS mypolicy ON mydataset.mytable`;
-      expect(format(input)).toBe(expected);
-    });
-
     it(`Supports DROP ALL ROW ACCESS POLICIES`, () => {
       const input = `
         DROP ALL ROW ACCESS POLICIES ON table_name`;


### PR DESCRIPTION
Removed lots of tests that checked for minor syntax variants. These just added lots of code to the tests without providing much real value.

There's now about 40 tests less for BigQuery.