### PR TITLE
Format ALTER TABLE and some other statements using oneline style

### DIFF
--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -38,7 +38,6 @@ const reservedClauses = expandPhrases([
   // Data definition, https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language
   'CREATE [OR REPLACE] [MATERIALIZED] VIEW [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [TEMP|TEMPORARY|SNAPSHOT|EXTERNAL] TABLE [IF NOT EXISTS]',
-  'DROP [SNAPSHOT | EXTERNAL] TABLE [IF EXISTS]',
 
   'CLUSTER BY',
   'FOR SYSTEM_TIME AS OF', // CREATE SNAPSHOT TABLE
@@ -48,6 +47,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP [SNAPSHOT | EXTERNAL] TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE [IF EXISTS]',
   'ADD COLUMN [IF NOT EXISTS]',

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -29,8 +29,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE',
   'SET',
-  // - delete:
-  'DELETE [FROM]',
   // - merge:
   'MERGE [INTO]',
   'WHEN [NOT] MATCHED [BY SOURCE | BY TARGET] [THEN]',
@@ -47,6 +45,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE [FROM]',
   // - drop table:
   'DROP [SNAPSHOT | EXTERNAL] TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -27,7 +27,6 @@ const reservedClauses = expandPhrases([
   'INSERT [INTO]',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
   // - merge:
   'MERGE [INTO]',
@@ -45,6 +44,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
   // - delete:
   'DELETE [FROM]',
   // - drop table:

--- a/src/languages/bigquery/bigquery.formatter.ts
+++ b/src/languages/bigquery/bigquery.formatter.ts
@@ -39,6 +39,15 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [MATERIALIZED] VIEW [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [TEMP|TEMPORARY|SNAPSHOT|EXTERNAL] TABLE [IF NOT EXISTS]',
   'DROP [SNAPSHOT | EXTERNAL] TABLE [IF EXISTS]',
+
+  'CLUSTER BY',
+  'FOR SYSTEM_TIME AS OF', // CREATE SNAPSHOT TABLE
+  'WITH CONNECTION',
+  'WITH PARTITION COLUMNS',
+  'REMOTE WITH CONNECTION',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE [IF EXISTS]',
   'ADD COLUMN [IF NOT EXISTS]',
@@ -49,19 +58,12 @@ const reservedClauses = expandPhrases([
   'SET OPTIONS', // for alter column
   'DROP NOT NULL', // for alter column
   'SET DATA TYPE', // for alter column
-
-  'CLUSTER BY',
-  'FOR SYSTEM_TIME AS OF', // CREATE SNAPSHOT TABLE
-  'WITH CONNECTION',
-  'WITH PARTITION COLUMNS',
-  'REMOTE WITH CONNECTION',
+  // - alter schema
   'ALTER SCHEMA [IF EXISTS]',
-
+  // - alter view
   'ALTER [MATERIALIZED] VIEW [IF EXISTS]',
+  // - alter bi_capacity
   'ALTER BI_CAPACITY',
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE TABLE',
   // - create schema

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -22,10 +22,7 @@ const reservedClauses = expandPhrases([
   'INSERT INTO',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
-  'WHERE CURRENT OF',
-  'WITH {RR | RS | CS | UR}',
   // - merge:
   'MERGE INTO',
   'WHEN [NOT] MATCHED [THEN]',
@@ -37,6 +34,10 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
+  'WHERE CURRENT OF',
+  'WITH {RR | RS | CS | UR}',
   // - delete:
   'DELETE FROM',
   // - drop table:

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -26,8 +26,6 @@ const reservedClauses = expandPhrases([
   'SET',
   'WHERE CURRENT OF',
   'WITH {RR | RS | CS | UR}',
-  // - delete:
-  'DELETE FROM',
   // - merge:
   'MERGE INTO',
   'WHEN [NOT] MATCHED [THEN]',
@@ -39,6 +37,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM',
   // - drop table:
   'DROP TABLE [HIERARCHY]',
   // alter table:

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -37,6 +37,9 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] VIEW',
   'CREATE [GLOBAL TEMPORARY] TABLE',
   'DROP TABLE [HIERARCHY]',
+]);
+
+const onelineClauses = expandPhrases([
   // alter table:
   'ALTER TABLE',
   'ADD [COLUMN]',
@@ -46,9 +49,6 @@ const reservedClauses = expandPhrases([
   'SET DATA TYPE', // for alter column
   'SET NOT NULL', // for alter column
   'DROP {IDENTITY | EXPRESSION | DEFAULT | NOT NULL}', // for alter column
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE [TABLE]',
   // other

--- a/src/languages/db2/db2.formatter.ts
+++ b/src/languages/db2/db2.formatter.ts
@@ -36,10 +36,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [OR REPLACE] VIEW',
   'CREATE [GLOBAL TEMPORARY] TABLE',
-  'DROP TABLE [HIERARCHY]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [HIERARCHY]',
   // alter table:
   'ALTER TABLE',
   'ADD [COLUMN]',

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -28,7 +28,6 @@ const reservedClauses = expandPhrases([
   'INSERT INTO [TABLE]',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
   // - merge:
   'MERGE INTO',
@@ -48,6 +47,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
   // - delete:
   'DELETE FROM',
   // - drop table:

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -30,8 +30,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE',
   'SET',
-  // - delete:
-  'DELETE FROM',
   // - merge:
   'MERGE INTO',
   'WHEN [NOT] MATCHED [THEN]',
@@ -50,6 +48,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM',
   // - drop table:
   'DROP TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -48,12 +48,12 @@ const reservedClauses = expandPhrases([
   'CREATE [MATERIALIZED] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY] [EXTERNAL] TABLE [IF NOT EXISTS]',
   'DROP TABLE [IF EXISTS]',
-  // - alter table:
-  'ALTER TABLE',
-  'RENAME TO',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - alter table:
+  'ALTER TABLE',
+  'RENAME TO',
   // - truncate:
   'TRUNCATE [TABLE]',
   // other

--- a/src/languages/hive/hive.formatter.ts
+++ b/src/languages/hive/hive.formatter.ts
@@ -47,10 +47,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [MATERIALIZED] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY] [EXTERNAL] TABLE [IF NOT EXISTS]',
-  'DROP TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE',
   'RENAME TO',

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -28,8 +28,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE [LOW_PRIORITY] [IGNORE]',
   'SET',
-  // - delete:
-  'DELETE [LOW_PRIORITY] [QUICK] [IGNORE] FROM',
   // Data definition
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [TEMPORARY] TABLE [IF NOT EXISTS]',
@@ -38,6 +36,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE [LOW_PRIORITY] [QUICK] [IGNORE] FROM',
   // - drop table:
   'DROP [TEMPORARY] TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -33,12 +33,13 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [TEMPORARY] TABLE [IF NOT EXISTS]',
-  'DROP [TEMPORARY] TABLE [IF EXISTS]',
   // other
   'RETURNING',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP [TEMPORARY] TABLE [IF EXISTS]',
   // - alter table:
   'ALTER [ONLINE] [IGNORE] TABLE [IF EXISTS]',
   'ADD [COLUMN] [IF NOT EXISTS]',

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -34,6 +34,11 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [TEMPORARY] TABLE [IF NOT EXISTS]',
   'DROP [TEMPORARY] TABLE [IF EXISTS]',
+  // other
+  'RETURNING',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER [ONLINE] [IGNORE] TABLE [IF EXISTS]',
   'ADD [COLUMN] [IF NOT EXISTS]',
@@ -44,11 +49,6 @@ const reservedClauses = expandPhrases([
   'ALTER [COLUMN]',
   '{SET | DROP} DEFAULT', // for alter column
   'SET {VISIBLE | INVISIBLE}', // for alter column
-  // other
-  'RETURNING',
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE [TABLE]',
   // https://mariadb.com/docs/reference/mdb/sql-statements/

--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -26,7 +26,6 @@ const reservedClauses = expandPhrases([
   'REPLACE [LOW_PRIORITY | DELAYED] [INTO]',
   'VALUES',
   // - update:
-  'UPDATE [LOW_PRIORITY] [IGNORE]',
   'SET',
   // Data definition
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
@@ -36,6 +35,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE [LOW_PRIORITY] [IGNORE]',
   // - delete:
   'DELETE [LOW_PRIORITY] [QUICK] [IGNORE] FROM',
   // - drop table:

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -34,6 +34,9 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY] TABLE [IF NOT EXISTS]',
   'DROP [TEMPORARY] TABLE [IF EXISTS]',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE',
   'ADD [COLUMN]',
@@ -43,9 +46,6 @@ const reservedClauses = expandPhrases([
   'RENAME COLUMN',
   'ALTER [COLUMN]',
   '{SET | DROP} DEFAULT', // for alter column
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE [TABLE]',
   // https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -26,7 +26,6 @@ const reservedClauses = expandPhrases([
   'REPLACE [LOW_PRIORITY | DELAYED] [INTO]',
   'VALUES',
   // - update:
-  'UPDATE [LOW_PRIORITY] [IGNORE]',
   'SET',
   // Data definition
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
@@ -34,6 +33,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE [LOW_PRIORITY] [IGNORE]',
   // - delete:
   'DELETE [LOW_PRIORITY] [QUICK] [IGNORE] FROM',
   // - drop table:

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -28,14 +28,14 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE [LOW_PRIORITY] [IGNORE]',
   'SET',
-  // - delete:
-  'DELETE [LOW_PRIORITY] [QUICK] [IGNORE] FROM',
   // Data definition
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY] TABLE [IF NOT EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE [LOW_PRIORITY] [QUICK] [IGNORE] FROM',
   // - drop table:
   'DROP [TEMPORARY] TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -33,10 +33,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [OR REPLACE] [SQL SECURITY DEFINER | SQL SECURITY INVOKER] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY] TABLE [IF NOT EXISTS]',
-  'DROP [TEMPORARY] TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP [TEMPORARY] TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE',
   'ADD [COLUMN]',

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -24,7 +24,6 @@ const reservedClauses = expandPhrases([
   'INSERT INTO',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
   // - merge:
   'MERGE INTO',
@@ -39,6 +38,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
   // - delete:
   'DELETE FROM',
   // - set schema:

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -31,7 +31,6 @@ const reservedClauses = expandPhrases([
   'UPDATE SET',
   'INSERT',
   // other
-  'USE KEYS',
   'NEST',
   'UNNEST',
   'RETURNING',
@@ -76,6 +75,7 @@ const onelineClauses = expandPhrases([
   'LET',
   'SET CURRENT SCHEMA',
   'SHOW',
+  'USE [PRIMARY] KEYS',
 ]);
 
 const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT [ALL]', 'INTERSECT [ALL]']);

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -41,6 +41,7 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - set schema:
   'SET SCHEMA',
   // https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/reservedwords.html
   'ADVISE',

--- a/src/languages/n1ql/n1ql.formatter.ts
+++ b/src/languages/n1ql/n1ql.formatter.ts
@@ -26,8 +26,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE',
   'SET',
-  // - delete:
-  'DELETE FROM',
   // - merge:
   'MERGE INTO',
   'WHEN [NOT] MATCHED THEN',
@@ -41,6 +39,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM',
   // - set schema:
   'SET SCHEMA',
   // https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/reservedwords.html

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -25,7 +25,6 @@ const reservedClauses = expandPhrases([
   'INSERT [INTO | ALL INTO]',
   'VALUES',
   // - update:
-  'UPDATE [ONLY]',
   'SET',
   // - merge:
   'MERGE [INTO]',
@@ -40,6 +39,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE [ONLY]',
   // - delete:
   'DELETE FROM [ONLY]',
   // - drop table:

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -38,6 +38,11 @@ const reservedClauses = expandPhrases([
   'CREATE MATERIALIZED VIEW',
   'CREATE [GLOBAL TEMPORARY | PRIVATE TEMPORARY | SHARDED | DUPLICATED | IMMUTABLE BLOCKCHAIN | BLOCKCHAIN | IMMUTABLE] TABLE',
   'DROP TABLE',
+  // other
+  'RETURNING',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE',
   'ADD',
@@ -45,11 +50,6 @@ const reservedClauses = expandPhrases([
   'MODIFY',
   'RENAME TO',
   'RENAME COLUMN',
-  // other
-  'RETURNING',
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE TABLE',
   // other

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -37,12 +37,13 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [NO FORCE | FORCE] [EDITIONING | EDITIONABLE | EDITIONABLE EDITIONING | NONEDITIONABLE] VIEW',
   'CREATE MATERIALIZED VIEW',
   'CREATE [GLOBAL TEMPORARY | PRIVATE TEMPORARY | SHARDED | DUPLICATED | IMMUTABLE BLOCKCHAIN | BLOCKCHAIN | IMMUTABLE] TABLE',
-  'DROP TABLE',
   // other
   'RETURNING',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE',
   // - alter table:
   'ALTER TABLE',
   'ADD',

--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -27,8 +27,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE [ONLY]',
   'SET',
-  // - delete:
-  'DELETE FROM [ONLY]',
   // - merge:
   'MERGE [INTO]',
   'WHEN [NOT] MATCHED [THEN]',
@@ -42,6 +40,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM [ONLY]',
   // - drop table:
   'DROP TABLE',
   // - alter table:

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -28,8 +28,6 @@ const reservedClauses = expandPhrases([
   'UPDATE [ONLY]',
   'SET',
   'WHERE CURRENT OF',
-  // - delete:
-  'DELETE FROM [ONLY]',
   // Data definition
   'CREATE [OR REPLACE] [TEMP | TEMPORARY] [RECURSIVE] VIEW',
   'CREATE MATERIALIZED VIEW [IF NOT EXISTS]',
@@ -39,6 +37,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM [ONLY]',
   // - drop table:
   'DROP TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -35,6 +35,11 @@ const reservedClauses = expandPhrases([
   'CREATE MATERIALIZED VIEW [IF NOT EXISTS]',
   'CREATE [GLOBAL | LOCAL] [TEMPORARY | TEMP | UNLOGGED] TABLE [IF NOT EXISTS]',
   'DROP TABLE [IF EXISTS]',
+  // other
+  'RETURNING',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE [IF EXISTS] [ONLY]',
   'ALTER TABLE ALL IN TABLESPACE',
@@ -46,11 +51,6 @@ const reservedClauses = expandPhrases([
   '[SET DATA] TYPE', // for alter column
   '{SET | DROP} DEFAULT', // for alter column
   '{SET | DROP} NOT NULL', // for alter column
-  // other
-  'RETURNING',
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE [TABLE] [ONLY]',
   // other

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -25,9 +25,7 @@ const reservedClauses = expandPhrases([
   'INSERT INTO',
   'VALUES',
   // - update:
-  'UPDATE [ONLY]',
   'SET',
-  'WHERE CURRENT OF',
   // Data definition
   'CREATE [OR REPLACE] [TEMP | TEMPORARY] [RECURSIVE] VIEW',
   'CREATE MATERIALIZED VIEW [IF NOT EXISTS]',
@@ -37,6 +35,9 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE [ONLY]',
+  'WHERE CURRENT OF',
   // - delete:
   'DELETE FROM [ONLY]',
   // - drop table:

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -34,12 +34,13 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [TEMP | TEMPORARY] [RECURSIVE] VIEW',
   'CREATE MATERIALIZED VIEW [IF NOT EXISTS]',
   'CREATE [GLOBAL | LOCAL] [TEMPORARY | TEMP | UNLOGGED] TABLE [IF NOT EXISTS]',
-  'DROP TABLE [IF EXISTS]',
   // other
   'RETURNING',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE [IF EXISTS] [ONLY]',
   'ALTER TABLE ALL IN TABLESPACE',

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -30,10 +30,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [OR REPLACE | MATERIALIZED] VIEW',
   'CREATE [TEMPORARY | TEMP | LOCAL TEMPORARY | LOCAL TEMP] TABLE [IF NOT EXISTS]',
-  'DROP TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE',
   'ALTER TABLE APPEND',

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -25,14 +25,14 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE',
   'SET',
-  // - delete:
-  'DELETE [FROM]',
   // Data definition
   'CREATE [OR REPLACE | MATERIALIZED] VIEW',
   'CREATE [TEMPORARY | TEMP | LOCAL TEMPORARY | LOCAL TEMP] TABLE [IF NOT EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE [FROM]',
   // - drop table:
   'DROP TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -23,7 +23,6 @@ const reservedClauses = expandPhrases([
   'INSERT INTO',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
   // Data definition
   'CREATE [OR REPLACE | MATERIALIZED] VIEW',
@@ -31,6 +30,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
   // - delete:
   'DELETE [FROM]',
   // - drop table:

--- a/src/languages/redshift/redshift.formatter.ts
+++ b/src/languages/redshift/redshift.formatter.ts
@@ -31,6 +31,9 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE | MATERIALIZED] VIEW',
   'CREATE [TEMPORARY | TEMP | LOCAL TEMPORARY | LOCAL TEMP] TABLE [IF NOT EXISTS]',
   'DROP TABLE [IF EXISTS]',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE',
   'ALTER TABLE APPEND',
@@ -41,9 +44,6 @@ const reservedClauses = expandPhrases([
   'ALTER COLUMN',
   'TYPE', // for alter column
   'ENCODE', // for alter column
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE [TABLE]',
   // https://docs.aws.amazon.com/redshift/latest/dg/c_SQL_commands.html

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -35,6 +35,9 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [TEMPORARY] PROCEDURE [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [EXTERNAL] FUNCTION',
   'DROP [TEMPORARY] TABLE [IF EXISTS]',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER [ONLINE] TABLE',
   'ADD [COLUMN]',
@@ -43,9 +46,6 @@ const reservedClauses = expandPhrases([
   'MODIFY [COLUMN]',
   'CHANGE',
   'RENAME [TO | AS]',
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE [TABLE]',
   // https://docs.singlestore.com/managed-service/en/reference/sql-reference.html

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -27,8 +27,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE',
   'SET',
-  // - delete:
-  'DELETE [FROM]',
   // Data definition
   'CREATE VIEW',
   'CREATE [ROWSTORE] [REFERENCE | TEMPORARY | GLOBAL TEMPORARY] TABLE [IF NOT EXISTS]',
@@ -37,6 +35,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE [FROM]',
   // - drop table:
   'DROP [TEMPORARY] TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -34,10 +34,11 @@ const reservedClauses = expandPhrases([
   'CREATE [ROWSTORE] [REFERENCE | TEMPORARY | GLOBAL TEMPORARY] TABLE [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [TEMPORARY] PROCEDURE [IF NOT EXISTS]',
   'CREATE [OR REPLACE] [EXTERNAL] FUNCTION',
-  'DROP [TEMPORARY] TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP [TEMPORARY] TABLE [IF EXISTS]',
   // - alter table:
   'ALTER [ONLINE] TABLE',
   'ADD [COLUMN]',

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -25,7 +25,6 @@ const reservedClauses = expandPhrases([
   'VALUES',
   'REPLACE [INTO]',
   // - update:
-  'UPDATE',
   'SET',
   // Data definition
   'CREATE VIEW',
@@ -35,6 +34,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
   // - delete:
   'DELETE [FROM]',
   // - drop table:

--- a/src/languages/snowflake/snowflake.formatter.ts
+++ b/src/languages/snowflake/snowflake.formatter.ts
@@ -43,10 +43,11 @@ const reservedClauses = expandPhrases([
   'WHEN MATCHED [AND]',
   'THEN {UPDATE SET | DELETE}',
   'WHEN NOT MATCHED THEN INSERT',
-  'DROP TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE [IF EXISTS]',
   'RENAME TO',

--- a/src/languages/snowflake/snowflake.formatter.ts
+++ b/src/languages/snowflake/snowflake.formatter.ts
@@ -27,8 +27,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE',
   'SET',
-  // - delete:
-  'DELETE FROM',
   // Data definition
   // - view
   'CREATE [OR REPLACE] [SECURE] [RECURSIVE] VIEW [IF NOT EXISTS]',
@@ -46,6 +44,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM',
   // - drop table:
   'DROP TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/snowflake/snowflake.formatter.ts
+++ b/src/languages/snowflake/snowflake.formatter.ts
@@ -25,7 +25,6 @@ const reservedClauses = expandPhrases([
   '{THEN | ELSE} INTO',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
   // Data definition
   // - view
@@ -44,6 +43,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
   // - delete:
   'DELETE FROM',
   // - drop table:

--- a/src/languages/snowflake/snowflake.formatter.ts
+++ b/src/languages/snowflake/snowflake.formatter.ts
@@ -44,6 +44,9 @@ const reservedClauses = expandPhrases([
   'THEN {UPDATE SET | DELETE}',
   'WHEN NOT MATCHED THEN INSERT',
   'DROP TABLE [IF EXISTS]',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE [IF EXISTS]',
   'RENAME TO',
@@ -57,7 +60,7 @@ const reservedClauses = expandPhrases([
   '{ADD | ALTER | MODIFY | DROP} [CONSTRAINT]',
   'RENAME CONSTRAINT',
   '{ADD | DROP} SEARCH OPTIMIZATION',
-  '{SET | UNSET} [TAG]',
+  '{SET | UNSET} TAG', // Actually TAG is optional, but that conflicts with UPDATE..SET statement
   '{ADD | DROP} ROW ACCESS POLICY',
   'DROP ALL ROW ACCESS POLICIES',
   '{SET | DROP} DEFAULT', // for alter column
@@ -65,9 +68,6 @@ const reservedClauses = expandPhrases([
   '[SET DATA] TYPE', // for alter column
   '[UNSET] COMMENT', // for alter column
   '{SET | UNSET} MASKING POLICY', // for alter column
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE [TABLE] [IF EXISTS]',
   // other

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -37,10 +37,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [OR REPLACE] [GLOBAL TEMPORARY | TEMPORARY] VIEW [IF NOT EXISTS]',
   'CREATE [EXTERNAL] TABLE [IF NOT EXISTS]',
-  'DROP TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE',
   'ADD COLUMNS',

--- a/src/languages/spark/spark.formatter.ts
+++ b/src/languages/spark/spark.formatter.ts
@@ -38,6 +38,9 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [GLOBAL TEMPORARY | TEMPORARY] VIEW [IF NOT EXISTS]',
   'CREATE [EXTERNAL] TABLE [IF NOT EXISTS]',
   'DROP TABLE [IF EXISTS]',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE',
   'ADD COLUMNS',
@@ -45,9 +48,6 @@ const reservedClauses = expandPhrases([
   'RENAME TO',
   'RENAME COLUMN',
   'ALTER COLUMN',
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE TABLE',
   // other

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -33,10 +33,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [RECURSIVE] VIEW',
   'CREATE [GLOBAL TEMPORARY | LOCAL TEMPORARY] TABLE',
-  'DROP TABLE',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE',
   // - alter table:
   'ALTER TABLE',
   'ADD COLUMN',

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -34,6 +34,9 @@ const reservedClauses = expandPhrases([
   'CREATE [RECURSIVE] VIEW',
   'CREATE [GLOBAL TEMPORARY | LOCAL TEMPORARY] TABLE',
   'DROP TABLE',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE',
   'ADD COLUMN',
@@ -45,9 +48,6 @@ const reservedClauses = expandPhrases([
   'ADD SCOPE', // for alter column
   'DROP SCOPE {CASCADE | RESTRICT}', // for alter column
   'RESTART WITH', // for alter column
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE TABLE',
   // other

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -28,14 +28,14 @@ const reservedClauses = expandPhrases([
   'UPDATE',
   'SET',
   'WHERE CURRENT OF',
-  // - delete:
-  'DELETE FROM',
   // Data definition
   'CREATE [RECURSIVE] VIEW',
   'CREATE [GLOBAL TEMPORARY | LOCAL TEMPORARY] TABLE',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM',
   // - drop table:
   'DROP TABLE',
   // - alter table:

--- a/src/languages/sql/sql.formatter.ts
+++ b/src/languages/sql/sql.formatter.ts
@@ -25,15 +25,16 @@ const reservedClauses = expandPhrases([
   'INSERT INTO',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
-  'WHERE CURRENT OF',
   // Data definition
   'CREATE [RECURSIVE] VIEW',
   'CREATE [GLOBAL TEMPORARY | LOCAL TEMPORARY] TABLE',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
+  'WHERE CURRENT OF',
   // - delete:
   'DELETE FROM',
   // - drop table:

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -27,14 +27,14 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE [OR ABORT | OR FAIL | OR IGNORE | OR REPLACE | OR ROLLBACK]',
   'SET',
-  // - delete:
-  'DELETE FROM',
   // Data definition
   'CREATE [TEMPORARY | TEMP] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY | TEMP] TABLE [IF NOT EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM',
   // - drop table:
   'DROP TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -25,7 +25,6 @@ const reservedClauses = expandPhrases([
   'REPLACE INTO',
   'VALUES',
   // - update:
-  'UPDATE [OR ABORT | OR FAIL | OR IGNORE | OR REPLACE | OR ROLLBACK]',
   'SET',
   // Data definition
   'CREATE [TEMPORARY | TEMP] VIEW [IF NOT EXISTS]',
@@ -33,6 +32,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE [OR ABORT | OR FAIL | OR IGNORE | OR REPLACE | OR ROLLBACK]',
   // - delete:
   'DELETE FROM',
   // - drop table:

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -33,15 +33,18 @@ const reservedClauses = expandPhrases([
   'CREATE [TEMPORARY | TEMP] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY | TEMP] TABLE [IF NOT EXISTS]',
   'DROP TABLE [IF EXISTS]',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE',
   'ADD [COLUMN]',
   'DROP [COLUMN]',
   'RENAME [COLUMN]',
   'RENAME TO',
+  // - set schema
+  'SET SCHEMA',
 ]);
-
-const onelineClauses = expandPhrases(['SET SCHEMA']);
 
 const reservedSetOperations = expandPhrases(['UNION [ALL]', 'EXCEPT', 'INTERSECT']);
 

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -32,10 +32,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [TEMPORARY | TEMP] VIEW [IF NOT EXISTS]',
   'CREATE [TEMPORARY | TEMP] TABLE [IF NOT EXISTS]',
-  'DROP TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE',
   'ADD [COLUMN]',

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -27,8 +27,6 @@ const reservedClauses = expandPhrases([
   'UPDATE',
   'SET',
   'WHERE CURRENT OF',
-  // - delete:
-  'DELETE [FROM]',
   // - merge:
   'MERGE [INTO]',
   'WHEN [NOT] MATCHED [BY TARGET | BY SOURCE] [THEN]',
@@ -39,6 +37,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE [FROM]',
   // - drop table:
   'DROP TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -36,10 +36,11 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [OR ALTER] [MATERIALIZED] VIEW',
   'CREATE TABLE',
-  'DROP TABLE [IF EXISTS]',
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE',
   'ADD',

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -37,14 +37,14 @@ const reservedClauses = expandPhrases([
   'CREATE [OR ALTER] [MATERIALIZED] VIEW',
   'CREATE TABLE',
   'DROP TABLE [IF EXISTS]',
+]);
+
+const onelineClauses = expandPhrases([
   // - alter table:
   'ALTER TABLE',
   'ADD',
   'DROP COLUMN [IF EXISTS]',
   'ALTER COLUMN',
-]);
-
-const onelineClauses = expandPhrases([
   // - truncate:
   'TRUNCATE TABLE',
   // https://docs.microsoft.com/en-us/sql/t-sql/statements/statements?view=sql-server-ver15

--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -24,9 +24,7 @@ const reservedClauses = expandPhrases([
   'INSERT [INTO]',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
-  'WHERE CURRENT OF',
   // - merge:
   'MERGE [INTO]',
   'WHEN [NOT] MATCHED [BY TARGET | BY SOURCE] [THEN]',
@@ -37,6 +35,9 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
+  'WHERE CURRENT OF',
   // - delete:
   'DELETE [FROM]',
   // - drop table:

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -26,7 +26,6 @@ const reservedClauses = expandPhrases([
   'INSERT INTO',
   'VALUES',
   // - update:
-  'UPDATE',
   'SET',
   // Data definition
   'CREATE [OR REPLACE] [MATERIALIZED] VIEW',
@@ -43,6 +42,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - update:
+  'UPDATE',
   // - delete:
   'DELETE FROM',
   // - drop table:

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -28,8 +28,6 @@ const reservedClauses = expandPhrases([
   // - update:
   'UPDATE',
   'SET',
-  // - delete:
-  'DELETE FROM',
   // Data definition
   'CREATE [OR REPLACE] [MATERIALIZED] VIEW',
   'CREATE TABLE [IF NOT EXISTS]',
@@ -45,6 +43,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - delete:
+  'DELETE FROM',
   // - drop table:
   'DROP TABLE [IF EXISTS]',
   // - alter table:

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -33,7 +33,6 @@ const reservedClauses = expandPhrases([
   // Data definition
   'CREATE [OR REPLACE] [MATERIALIZED] VIEW',
   'CREATE TABLE [IF NOT EXISTS]',
-  'DROP TABLE [IF EXISTS]',
   // MATCH_RECOGNIZE
   'MATCH_RECOGNIZE',
   'MEASURES',
@@ -46,6 +45,8 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - drop table:
+  'DROP TABLE [IF EXISTS]',
   // - alter table:
   'ALTER TABLE [IF EXISTS]',
   'ADD COLUMN [IF NOT EXISTS]',

--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -34,15 +34,6 @@ const reservedClauses = expandPhrases([
   'CREATE [OR REPLACE] [MATERIALIZED] VIEW',
   'CREATE TABLE [IF NOT EXISTS]',
   'DROP TABLE [IF EXISTS]',
-  // - alter table:
-  'ALTER TABLE [IF EXISTS]',
-  'ADD COLUMN [IF NOT EXISTS]',
-  'DROP COLUMN [IF EXISTS]',
-  'RENAME COLUMN [IF EXISTS]',
-  'RENAME TO',
-  'SET AUTHORIZATION [USER | ROLE]',
-  'SET PROPERTIES',
-  'EXECUTE',
   // MATCH_RECOGNIZE
   'MATCH_RECOGNIZE',
   'MEASURES',
@@ -55,6 +46,15 @@ const reservedClauses = expandPhrases([
 ]);
 
 const onelineClauses = expandPhrases([
+  // - alter table:
+  'ALTER TABLE [IF EXISTS]',
+  'ADD COLUMN [IF NOT EXISTS]',
+  'DROP COLUMN [IF EXISTS]',
+  'RENAME COLUMN [IF EXISTS]',
+  'RENAME TO',
+  'SET AUTHORIZATION [USER | ROLE]',
+  'SET PROPERTIES',
+  'EXECUTE',
   // - truncate:
   'TRUNCATE TABLE',
 

--- a/test/behavesLikeMariaDbFormatter.ts
+++ b/test/behavesLikeMariaDbFormatter.ts
@@ -102,10 +102,8 @@ export default function behavesLikeMariaDbFormatter(format: FormatFn) {
   // Issue #181
   it('does not wrap CHARACTER SET to multiple lines', () => {
     expect(format('ALTER TABLE t MODIFY col1 VARCHAR(50) CHARACTER SET greek')).toBe(dedent`
-      ALTER TABLE
-        t
-      MODIFY
-        col1 VARCHAR(50) CHARACTER SET greek
+      ALTER TABLE t
+      MODIFY col1 VARCHAR(50) CHARACTER SET greek
     `);
   });
 

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -436,10 +436,8 @@ describe('BigQueryFormatter', () => {
         ALTER SCHEMA mydataset
         SET DEFAULT COLLATE 'und:ci'`;
       const expected = dedent`
-        ALTER SCHEMA
-          mydataset
-        SET DEFAULT COLLATE
-          'und:ci'`;
+        ALTER SCHEMA mydataset
+        SET DEFAULT COLLATE 'und:ci'`;
       expect(format(input)).toBe(expected);
     });
 
@@ -450,10 +448,8 @@ describe('BigQueryFormatter', () => {
           default_table_expiration_days=3.75
           )`;
       const expected = dedent`
-        ALTER SCHEMA
-          mydataset
-        SET OPTIONS
-          (default_table_expiration_days = 3.75)`;
+        ALTER SCHEMA mydataset
+        SET OPTIONS (default_table_expiration_days = 3.75)`;
       expect(format(input)).toBe(expected);
     });
 
@@ -464,12 +460,10 @@ describe('BigQueryFormatter', () => {
           expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
         )`;
       const expected = dedent`
-        ALTER TABLE
-          mydataset.mytable
-        SET OPTIONS
-          (
-            expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
-          )`;
+        ALTER TABLE mydataset.mytable
+        SET OPTIONS (
+          expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+        )`;
       expect(format(input)).toBe(expected);
     });
 
@@ -478,10 +472,8 @@ describe('BigQueryFormatter', () => {
         ALTER TABLE mydataset.mytable
         SET DEFAULT COLLATE 'und:ci'`;
       const expected = dedent`
-        ALTER TABLE
-          mydataset.mytable
-        SET DEFAULT COLLATE
-          'und:ci'`;
+        ALTER TABLE mydataset.mytable
+        SET DEFAULT COLLATE 'und:ci'`;
       expect(format(input)).toBe(expected);
     });
 
@@ -493,12 +485,9 @@ describe('BigQueryFormatter', () => {
           description="Price per unit"
         )`;
       const expected = dedent`
-        ALTER TABLE
-          mydataset.mytable
-        ALTER COLUMN
-          price
-        SET OPTIONS
-          (description = "Price per unit")`;
+        ALTER TABLE mydataset.mytable
+        ALTER COLUMN price
+        SET OPTIONS (description = "Price per unit")`;
       expect(format(input)).toBe(expected);
     });
 
@@ -508,10 +497,8 @@ describe('BigQueryFormatter', () => {
         ALTER COLUMN price
         DROP NOT NULL`;
       const expected = dedent`
-        ALTER TABLE
-          mydataset.mytable
-        ALTER COLUMN
-          price
+        ALTER TABLE mydataset.mytable
+        ALTER COLUMN price
         DROP NOT NULL`;
       expect(format(input)).toBe(expected);
     });
@@ -522,12 +509,9 @@ describe('BigQueryFormatter', () => {
         ALTER COLUMN price
         SET DATA TYPE NUMERIC`;
       const expected = dedent`
-        ALTER TABLE
-          mydataset.mytable
-        ALTER COLUMN
-          price
-        SET DATA TYPE
-          NUMERIC`;
+        ALTER TABLE mydataset.mytable
+        ALTER COLUMN price
+        SET DATA TYPE NUMERIC`;
       expect(format(input)).toBe(expected);
     });
 
@@ -538,12 +522,10 @@ describe('BigQueryFormatter', () => {
           expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
         )`;
       const expected = dedent`
-        ALTER VIEW
-          mydataset.myview
-        SET OPTIONS
-          (
-            expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
-          )`;
+        ALTER VIEW mydataset.myview
+        SET OPTIONS (
+          expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+        )`;
       expect(format(input)).toBe(expected);
     });
 
@@ -554,10 +536,8 @@ describe('BigQueryFormatter', () => {
           size_gb = 250
         )`;
       const expected = dedent`
-        ALTER BI_CAPACITY
-          my-project.region-us.default
-        SET OPTIONS
-          (size_gb = 250)`;
+        ALTER BI_CAPACITY my-project.region-us.default
+        SET OPTIONS (size_gb = 250)`;
       expect(format(input)).toBe(expected);
     });
   });

--- a/test/db2.test.ts
+++ b/test/db2.test.ts
@@ -118,17 +118,12 @@ describe('Db2Formatter', () => {
          ALTER TABLE t ALTER COLUMN foo SET NOT NULL;`
       )
     ).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DATA TYPE
-        VARCHAR;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DATA TYPE VARCHAR;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       SET NOT NULL;
     `);
   });

--- a/test/db2.test.ts
+++ b/test/db2.test.ts
@@ -103,8 +103,7 @@ describe('Db2Formatter', () => {
 
   it('supports WITH isolation level modifiers for UPDATE statement', () => {
     expect(format('UPDATE foo SET x = 10 WITH CS')).toBe(dedent`
-      UPDATE
-        foo
+      UPDATE foo
       SET
         x = 10
       WITH CS

--- a/test/features/alterTable.ts
+++ b/test/features/alterTable.ts
@@ -15,10 +15,8 @@ export default function supportsAlterTable(format: FormatFn, cfg: AlterTableConf
     it('formats ALTER TABLE ... ADD COLUMN query', () => {
       const result = format('ALTER TABLE supplier ADD COLUMN unit_price DECIMAL NOT NULL;');
       expect(result).toBe(dedent`
-        ALTER TABLE
-          supplier
-        ADD COLUMN
-          unit_price DECIMAL NOT NULL;
+        ALTER TABLE supplier
+        ADD COLUMN unit_price DECIMAL NOT NULL;
       `);
     });
   }
@@ -27,10 +25,8 @@ export default function supportsAlterTable(format: FormatFn, cfg: AlterTableConf
     it('formats ALTER TABLE ... DROP COLUMN query', () => {
       const result = format('ALTER TABLE supplier DROP COLUMN unit_price;');
       expect(result).toBe(dedent`
-        ALTER TABLE
-          supplier
-        DROP COLUMN
-          unit_price;
+        ALTER TABLE supplier
+        DROP COLUMN unit_price;
       `);
     });
   }
@@ -39,10 +35,8 @@ export default function supportsAlterTable(format: FormatFn, cfg: AlterTableConf
     it('formats ALTER TABLE ... MODIFY statement', () => {
       const result = format('ALTER TABLE supplier MODIFY supplier_id DECIMAL NULL;');
       expect(result).toBe(dedent`
-        ALTER TABLE
-          supplier
-        MODIFY
-          supplier_id DECIMAL NULL;
+        ALTER TABLE supplier
+        MODIFY supplier_id DECIMAL NULL;
       `);
     });
   }
@@ -51,10 +45,8 @@ export default function supportsAlterTable(format: FormatFn, cfg: AlterTableConf
     it('formats ALTER TABLE ... RENAME TO statement', () => {
       const result = format('ALTER TABLE supplier RENAME TO the_one_who_supplies;');
       expect(result).toBe(dedent`
-        ALTER TABLE
-          supplier
-        RENAME TO
-          the_one_who_supplies;
+        ALTER TABLE supplier
+        RENAME TO the_one_who_supplies;
       `);
     });
   }
@@ -63,10 +55,8 @@ export default function supportsAlterTable(format: FormatFn, cfg: AlterTableConf
     it('formats ALTER TABLE ... RENAME COLUMN statement', () => {
       const result = format('ALTER TABLE supplier RENAME COLUMN supplier_id TO id;');
       expect(result).toBe(dedent`
-        ALTER TABLE
-          supplier
-        RENAME COLUMN
-          supplier_id TO id;
+        ALTER TABLE supplier
+        RENAME COLUMN supplier_id TO id;
       `);
     });
   }

--- a/test/features/deleteFrom.ts
+++ b/test/features/deleteFrom.ts
@@ -13,8 +13,7 @@ export default function supportsDeleteFrom(
   it('formats DELETE FROM statement', () => {
     const result = format("DELETE FROM Customers WHERE CustomerName='Alfred' AND Phone=5002132;");
     expect(result).toBe(dedent`
-      DELETE FROM
-        Customers
+      DELETE FROM Customers
       WHERE
         CustomerName = 'Alfred'
         AND Phone = 5002132;
@@ -25,8 +24,7 @@ export default function supportsDeleteFrom(
     it('formats DELETE statement (without FROM)', () => {
       const result = format("DELETE Customers WHERE CustomerName='Alfred';");
       expect(result).toBe(dedent`
-        DELETE
-          Customers
+        DELETE Customers
         WHERE
           CustomerName = 'Alfred';
       `);

--- a/test/features/dropTable.ts
+++ b/test/features/dropTable.ts
@@ -10,8 +10,7 @@ export default function supportsDropTable(format: FormatFn, { ifExists }: DropTa
   it('formats DROP TABLE statement', () => {
     const result = format('DROP TABLE admin_role;');
     expect(result).toBe(dedent`
-      DROP TABLE
-        admin_role;
+      DROP TABLE admin_role;
     `);
   });
 
@@ -19,8 +18,7 @@ export default function supportsDropTable(format: FormatFn, { ifExists }: DropTa
     it('formats DROP TABLE IF EXISTS statement', () => {
       const result = format('DROP TABLE IF EXISTS admin_role;');
       expect(result).toBe(dedent`
-        DROP TABLE IF EXISTS
-          admin_role;
+        DROP TABLE IF EXISTS admin_role;
       `);
     });
   }

--- a/test/features/update.ts
+++ b/test/features/update.ts
@@ -12,8 +12,7 @@ export default function supportsUpdate(format: FormatFn, { whereCurrentOf }: Upd
       "UPDATE Customers SET ContactName='Alfred Schmidt', City='Hamburg' WHERE CustomerName='Alfreds Futterkiste';"
     );
     expect(result).toBe(dedent`
-      UPDATE
-        Customers
+      UPDATE Customers
       SET
         ContactName = 'Alfred Schmidt',
         City = 'Hamburg'
@@ -27,8 +26,7 @@ export default function supportsUpdate(format: FormatFn, { whereCurrentOf }: Upd
       'UPDATE customers SET total_orders = order_summary.total  FROM ( SELECT * FROM bank) AS order_summary'
     );
     expect(result).toBe(dedent`
-      UPDATE
-        customers
+      UPDATE customers
       SET
         total_orders = order_summary.total
       FROM
@@ -45,12 +43,10 @@ export default function supportsUpdate(format: FormatFn, { whereCurrentOf }: Upd
     it('formats UPDATE statement with cursor position', () => {
       const result = format("UPDATE Customers SET Name='John' WHERE CURRENT OF my_cursor;");
       expect(result).toBe(dedent`
-        UPDATE
-          Customers
+        UPDATE Customers
         SET
           Name = 'John'
-        WHERE CURRENT OF
-          my_cursor;
+        WHERE CURRENT OF my_cursor;
       `);
     });
   }

--- a/test/mariadb.test.ts
+++ b/test/mariadb.test.ts
@@ -77,17 +77,12 @@ describe('MariaDbFormatter', () => {
          ALTER TABLE t ALTER COLUMN foo DROP DEFAULT;`
       )
     ).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DEFAULT
-        10;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DEFAULT 10;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP DEFAULT;
     `);
   });

--- a/test/mysql.test.ts
+++ b/test/mysql.test.ts
@@ -84,17 +84,12 @@ describe('MySqlFormatter', () => {
          ALTER TABLE t ALTER COLUMN foo DROP DEFAULT;`
       )
     ).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DEFAULT
-        10;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DEFAULT 10;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP DEFAULT;
     `);
   });

--- a/test/n1ql.test.ts
+++ b/test/n1ql.test.ts
@@ -126,8 +126,7 @@ describe('N1qlFormatter', () => {
     const result = format("EXPLAIN DELETE FROM tutorial t USE KEYS 'baldwin'");
     expect(result).toBe(dedent`
       EXPLAIN
-      DELETE FROM
-        tutorial t
+      DELETE FROM tutorial t
       USE KEYS
         'baldwin'
     `);

--- a/test/n1ql.test.ts
+++ b/test/n1ql.test.ts
@@ -135,8 +135,7 @@ describe('N1qlFormatter', () => {
   it('formats UPDATE query with USE KEYS', () => {
     const result = format("UPDATE tutorial USE KEYS 'baldwin' SET type = 'actor'");
     expect(result).toBe(dedent`
-      UPDATE
-        tutorial
+      UPDATE tutorial
       USE KEYS
         'baldwin'
       SET

--- a/test/n1ql.test.ts
+++ b/test/n1ql.test.ts
@@ -115,8 +115,7 @@ describe('N1qlFormatter', () => {
         *
       FROM
         usr
-      USE KEYS
-        'Elinor_33313792'
+      USE KEYS 'Elinor_33313792'
       NEST
         orders_with_users orders ON KEYS ARRAY s.order_id FOR s IN usr.shipped_order_history END;
     `);
@@ -127,8 +126,7 @@ describe('N1qlFormatter', () => {
     expect(result).toBe(dedent`
       EXPLAIN
       DELETE FROM tutorial t
-      USE KEYS
-        'baldwin'
+      USE KEYS 'baldwin'
     `);
   });
 
@@ -136,8 +134,7 @@ describe('N1qlFormatter', () => {
     const result = format("UPDATE tutorial USE KEYS 'baldwin' SET type = 'actor'");
     expect(result).toBe(dedent`
       UPDATE tutorial
-      USE KEYS
-        'baldwin'
+      USE KEYS 'baldwin'
       SET
         type = 'actor'
     `);

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -237,36 +237,24 @@ describe('PostgreSqlFormatter', () => {
          ALTER TABLE t ALTER COLUMN foo DROP NOT NULL;`
       )
     ).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DATA TYPE
-        VARCHAR;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DATA TYPE VARCHAR;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DEFAULT
-        5;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DEFAULT 5;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP DEFAULT;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       SET NOT NULL;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP NOT NULL;
     `);
   });

--- a/test/redshift.test.ts
+++ b/test/redshift.test.ts
@@ -134,19 +134,13 @@ describe('RedshiftFormatter', () => {
          ALTER TABLE t ALTER COLUMN foo ENCODE my_encoding;`
       )
     ).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      TYPE
-        VARCHAR;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      TYPE VARCHAR;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      ENCODE
-        my_encoding;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      ENCODE my_encoding;
     `);
   });
 });

--- a/test/snowflake.test.ts
+++ b/test/snowflake.test.ts
@@ -106,77 +106,49 @@ describe('SnowflakeFormatter', () => {
          ALTER TABLE t ALTER COLUMN foo UNSET TAG tname;`
       )
     ).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DATA TYPE
-        VARCHAR;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DATA TYPE VARCHAR;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DEFAULT
-        5;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DEFAULT 5;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP DEFAULT;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       SET NOT NULL;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP NOT NULL;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      COMMENT
-        'blah';
+      ALTER TABLE t
+      ALTER COLUMN foo
+      COMMENT 'blah';
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       UNSET COMMENT;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET MASKING POLICY
-        polis;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET MASKING POLICY polis;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       UNSET MASKING POLICY;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET TAG
-        tname = 10;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET TAG tname = 10;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      UNSET TAG
-        tname;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      UNSET TAG tname;
     `);
   });
 });

--- a/test/spark.test.ts
+++ b/test/spark.test.ts
@@ -128,10 +128,8 @@ describe('SparkFormatter', () => {
   it('formats ALTER TABLE ... ALTER COLUMN', () => {
     expect(format(`ALTER TABLE StudentInfo ALTER COLUMN FirstName COMMENT "new comment";`))
       .toBe(dedent`
-      ALTER TABLE
-        StudentInfo
-      ALTER COLUMN
-        FirstName COMMENT "new comment";
+      ALTER TABLE StudentInfo
+      ALTER COLUMN FirstName COMMENT "new comment";
     `);
   });
 });

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -79,31 +79,21 @@ describe('SqlFormatter', () => {
          ALTER TABLE t ALTER COLUMN foo RESTART WITH 10;`
       )
     ).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      SET DEFAULT
-        5;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      SET DEFAULT 5;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP DEFAULT;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
+      ALTER TABLE t
+      ALTER COLUMN foo
       DROP SCOPE CASCADE;
 
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo
-      RESTART WITH
-        10;
+      ALTER TABLE t
+      ALTER COLUMN foo
+      RESTART WITH 10;
     `);
   });
 });

--- a/test/transactsql.test.ts
+++ b/test/transactsql.test.ts
@@ -113,10 +113,8 @@ describe('TransactSqlFormatter', () => {
 
   it('formats ALTER TABLE ... ALTER COLUMN', () => {
     expect(format(`ALTER TABLE t ALTER COLUMN foo INT NOT NULL DEFAULT 5;`)).toBe(dedent`
-      ALTER TABLE
-        t
-      ALTER COLUMN
-        foo INT NOT NULL DEFAULT 5;
+      ALTER TABLE t
+      ALTER COLUMN foo INT NOT NULL DEFAULT 5;
     `);
   });
 });


### PR DESCRIPTION
`ALTER TABLE`, `DROP TABLE`, `DELETE FROM` and `UPDATE` are now formatted as follows:

```sql
ALTER TABLE foo
ALTER COLUMN col1
SET DEFAULT 10;

DROP TABLE my_tbl;

DELETE FROM customers
WHERE
  age > 99;

UPDATE orders
SET
  price = 0,
  total = 0
WHERE
  deleted = TRUE;
```