### PR TITLE
Support nested CASE expressions

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -191,9 +191,9 @@ export default class ExpressionFormatter {
 
   private formatCaseExpression(node: CaseExpressionNode) {
     this.formatNode(node.caseKw);
-    this.layout = this.formatSubExpression(node.expr);
 
     this.layout.indentation.increaseBlockLevel();
+    this.layout = this.formatSubExpression(node.expr);
     this.layout = this.formatSubExpression(node.clauses);
     this.layout.indentation.decreaseBlockLevel();
 

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -146,7 +146,6 @@ free_form_sql -> ( asteriskless_free_form_sql | asterisk ) {% unwrap %}
 asteriskless_free_form_sql ->
   ( asteriskless_expression
   | between_predicate
-  | case_expression
   | comma
   | comment
   | other_keyword ) {% unwrap %}
@@ -155,6 +154,7 @@ expression -> ( asteriskless_expression | asterisk ) {% unwrap %}
 
 asteriskless_expression ->
   ( array_subscript
+  | case_expression
   | function_call
   | property_access
   | parenthesis

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -167,4 +167,34 @@ export default function supportsCase(format: FormatFn) {
       ].join('\n')
     );
   });
+
+  // Not a pretty result.
+  // This test is more to ensure we don't crash on this code.
+  it('formats nested case expressions', () => {
+    const result = format(`
+      SELECT
+        CASE
+          CASE foo WHEN 1 THEN 11 ELSE 22 END
+          WHEN 11 THEN 110
+          WHEN 22 THEN 220
+          ELSE 123
+        END
+      FROM
+        tbl;
+    `);
+
+    expect(result).toBe(dedent`
+      SELECT
+        CASE CASE foo
+            WHEN 1 THEN 11
+            ELSE 22
+          END
+          WHEN 11 THEN 110
+          WHEN 22 THEN 220
+          ELSE 123
+        END
+      FROM
+        tbl;
+    `);
+  });
 }


### PR DESCRIPTION
Turns out one can nest CASE-expressions. People writing code like that should probably be punished :)

However, our formatter shouldn't crash on this valid SQL syntax.