### PR TITLE
Support named function arguments in Trino with => operator

### DIFF
--- a/src/languages/trino/trino.formatter.ts
+++ b/src/languages/trino/trino.formatter.ts
@@ -148,6 +148,7 @@ export const trino: DialectOptions = {
     operators: [
       '%',
       '->',
+      '=>',
       ':',
       '||',
       // Row pattern syntax

--- a/test/trino.test.ts
+++ b/test/trino.test.ts
@@ -47,7 +47,7 @@ describe('TrinoFormatter', () => {
   supportsIdentifiers(format, [`""-qq`]);
   supportsBetween(format);
   // Missing: '?' operator (for row patterns)
-  supportsOperators(format, ['%', '->', '||', '|', '^', '$'], ['AND', 'OR']);
+  supportsOperators(format, ['%', '->', '=>', '||', '|', '^', '$'], ['AND', 'OR']);
   supportsArrayLiterals(format);
   supportsArrayAndMapAccessors(format);
   supportsJoin(format);


### PR DESCRIPTION
Using the `=>` operator like in Postgres.

Fixes #509