### PR TITLE
Single dialect import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,8 @@
       { "avoidEscape": true, "allowTemplateLiterals": true }
     ],
     "@typescript-eslint/semi": "error",
-    "@typescript-eslint/no-non-null-assertion": "error"
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/consistent-type-exports": "error"
   },
   "settings": {
     "import/resolver": {

--- a/src/allDialects.ts
+++ b/src/allDialects.ts
@@ -1,0 +1,16 @@
+export { bigquery } from './languages/bigquery/bigquery.formatter.js';
+export { db2 } from './languages/db2/db2.formatter.js';
+export { hive } from './languages/hive/hive.formatter.js';
+export { mariadb } from './languages/mariadb/mariadb.formatter.js';
+export { mysql } from './languages/mysql/mysql.formatter.js';
+export { n1ql } from './languages/n1ql/n1ql.formatter.js';
+export { plsql } from './languages/plsql/plsql.formatter.js';
+export { postgresql } from './languages/postgresql/postgresql.formatter.js';
+export { redshift } from './languages/redshift/redshift.formatter.js';
+export { spark } from './languages/spark/spark.formatter.js';
+export { sqlite } from './languages/sqlite/sqlite.formatter.js';
+export { sql } from './languages/sql/sql.formatter.js';
+export { trino } from './languages/trino/trino.formatter.js';
+export { transactsql } from './languages/transactsql/transactsql.formatter.js';
+export { singlestoredb } from './languages/singlestoredb/singlestoredb.formatter.js';
+export { snowflake } from './languages/snowflake/snowflake.formatter.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-export * from './sqlFormatter.js';
+export {
+  SqlLanguage,
+  supportedDialects,
+  FormatOptionsWithLanguage,
+  FormatOptionsWithDialect,
+  format,
+  formatDialect,
+  ConfigError,
+} from './sqlFormatter.js';
 export type {
   IndentStyle,
   KeywordCase,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,14 @@ export {
   format,
   formatDialect,
 } from './sqlFormatter.js';
-export type {
+export {
   IndentStyle,
   KeywordCase,
   CommaPosition,
   LogicalOperatorNewline,
   FormatOptions,
 } from './FormatOptions.js';
-export type { DialectOptions } from './dialect.js';
+export { DialectOptions } from './dialect.js';
 export { ConfigError } from './validateConfig.js';
 export { expandPhrases } from './expandPhrases.js';
 export * from './allDialects.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 export { supportedDialects, format, formatDialect } from './sqlFormatter.js';
 export { expandPhrases } from './expandPhrases.js';
+
+// Intentionally use "export *" syntax here to make sure when adding a new SQL dialect
+// we wouldn't forget to expose it in our public API.
 export * from './allDialects.js';
 
 // NB! To re-export types the "export type" syntax is required by webpack.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ export {
   FormatOptionsWithDialect,
   format,
   formatDialect,
-  ConfigError,
 } from './sqlFormatter.js';
 export type {
   IndentStyle,
@@ -15,4 +14,5 @@ export type {
   FormatOptions,
 } from './FormatOptions.js';
 export type { DialectOptions } from './dialect.js';
+export { ConfigError } from './validateConfig.js';
 export { expandPhrases } from './expandPhrases.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,20 @@
-export {
+export { supportedDialects, format, formatDialect } from './sqlFormatter.js';
+export { expandPhrases } from './expandPhrases.js';
+export * from './allDialects.js';
+
+// NB! To re-export types the "export type" syntax is required by webpack.
+// Otherwise webpack build will fail.
+export type {
   SqlLanguage,
-  supportedDialects,
   FormatOptionsWithLanguage,
   FormatOptionsWithDialect,
-  format,
-  formatDialect,
 } from './sqlFormatter.js';
-export {
+export type {
   IndentStyle,
   KeywordCase,
   CommaPosition,
   LogicalOperatorNewline,
   FormatOptions,
 } from './FormatOptions.js';
-export { DialectOptions } from './dialect.js';
-export { ConfigError } from './validateConfig.js';
-export { expandPhrases } from './expandPhrases.js';
-export * from './allDialects.js';
+export type { DialectOptions } from './dialect.js';
+export type { ConfigError } from './validateConfig.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export type {
 export type { DialectOptions } from './dialect.js';
 export { ConfigError } from './validateConfig.js';
 export { expandPhrases } from './expandPhrases.js';
+export * from './allDialects.js';

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -20,7 +20,7 @@ import { ParamItems } from './formatter/Params.js';
 import { createDialect, DialectOptions } from './dialect.js';
 import Formatter from './formatter/Formatter.js';
 
-export const formatters = {
+const formatters = {
   bigquery,
   db2,
   hive,

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -1,19 +1,4 @@
-import { bigquery } from './languages/bigquery/bigquery.formatter.js';
-import { db2 } from './languages/db2/db2.formatter.js';
-import { hive } from './languages/hive/hive.formatter.js';
-import { mariadb } from './languages/mariadb/mariadb.formatter.js';
-import { mysql } from './languages/mysql/mysql.formatter.js';
-import { n1ql } from './languages/n1ql/n1ql.formatter.js';
-import { plsql } from './languages/plsql/plsql.formatter.js';
-import { postgresql } from './languages/postgresql/postgresql.formatter.js';
-import { redshift } from './languages/redshift/redshift.formatter.js';
-import { spark } from './languages/spark/spark.formatter.js';
-import { sqlite } from './languages/sqlite/sqlite.formatter.js';
-import { sql } from './languages/sql/sql.formatter.js';
-import { trino } from './languages/trino/trino.formatter.js';
-import { transactsql } from './languages/transactsql/transactsql.formatter.js';
-import { singlestoredb } from './languages/singlestoredb/singlestoredb.formatter.js';
-import { snowflake } from './languages/snowflake/snowflake.formatter.js';
+import * as allDialects from './allDialects.js';
 
 import { FormatOptions } from './FormatOptions.js';
 import { createDialect, DialectOptions } from './dialect.js';
@@ -21,23 +6,8 @@ import Formatter from './formatter/Formatter.js';
 import { ConfigError, validateConfig } from './validateConfig.js';
 
 const formatters = {
-  bigquery,
-  db2,
-  hive,
-  mariadb,
-  mysql,
-  n1ql,
-  plsql,
-  postgresql,
-  redshift,
-  singlestoredb,
-  snowflake,
-  spark,
-  sql,
-  sqlite,
-  transactsql,
-  trino,
-  tsql: transactsql, // alias for transactsql
+  ...allDialects,
+  tsql: allDialects.transactsql, // alias for transactsql
 };
 export type SqlLanguage = keyof typeof formatters;
 export const supportedDialects = Object.keys(formatters);

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -16,9 +16,9 @@ import { singlestoredb } from './languages/singlestoredb/singlestoredb.formatter
 import { snowflake } from './languages/snowflake/snowflake.formatter.js';
 
 import { FormatOptions } from './FormatOptions.js';
-import { ParamItems } from './formatter/Params.js';
 import { createDialect, DialectOptions } from './dialect.js';
 import Formatter from './formatter/Formatter.js';
+import { ConfigError, validateConfig } from './validateConfig.js';
 
 const formatters = {
   bigquery,
@@ -105,46 +105,5 @@ export const formatDialect = (
 
   return new Formatter(createDialect(dialect), options).format(query);
 };
-
-export class ConfigError extends Error {}
-
-function validateConfig(cfg: FormatOptions): FormatOptions {
-  if ('multilineLists' in cfg) {
-    throw new ConfigError('multilineLists config is no more supported.');
-  }
-  if ('newlineBeforeOpenParen' in cfg) {
-    throw new ConfigError('newlineBeforeOpenParen config is no more supported.');
-  }
-  if ('newlineBeforeCloseParen' in cfg) {
-    throw new ConfigError('newlineBeforeCloseParen config is no more supported.');
-  }
-  if ('aliasAs' in cfg) {
-    throw new ConfigError('aliasAs config is no more supported.');
-  }
-
-  if (cfg.expressionWidth <= 0) {
-    throw new ConfigError(
-      `expressionWidth config must be positive number. Received ${cfg.expressionWidth} instead.`
-    );
-  }
-
-  if (cfg.commaPosition === 'before' && cfg.useTabs) {
-    throw new ConfigError(
-      'commaPosition: before does not work when tabs are used for indentation.'
-    );
-  }
-
-  if (cfg.params && !validateParams(cfg.params)) {
-    // eslint-disable-next-line no-console
-    console.warn('WARNING: All "params" option values should be strings.');
-  }
-
-  return cfg;
-}
-
-function validateParams(params: ParamItems | string[]): boolean {
-  const paramValues = params instanceof Array ? params : Object.values(params);
-  return paramValues.every(p => typeof p === 'string');
-}
 
 export type FormatFn = typeof format;

--- a/src/validateConfig.ts
+++ b/src/validateConfig.ts
@@ -1,0 +1,43 @@
+import { FormatOptions } from './FormatOptions.js';
+import { ParamItems } from './formatter/Params.js';
+
+export class ConfigError extends Error {}
+
+export function validateConfig(cfg: FormatOptions): FormatOptions {
+  if ('multilineLists' in cfg) {
+    throw new ConfigError('multilineLists config is no more supported.');
+  }
+  if ('newlineBeforeOpenParen' in cfg) {
+    throw new ConfigError('newlineBeforeOpenParen config is no more supported.');
+  }
+  if ('newlineBeforeCloseParen' in cfg) {
+    throw new ConfigError('newlineBeforeCloseParen config is no more supported.');
+  }
+  if ('aliasAs' in cfg) {
+    throw new ConfigError('aliasAs config is no more supported.');
+  }
+
+  if (cfg.expressionWidth <= 0) {
+    throw new ConfigError(
+      `expressionWidth config must be positive number. Received ${cfg.expressionWidth} instead.`
+    );
+  }
+
+  if (cfg.commaPosition === 'before' && cfg.useTabs) {
+    throw new ConfigError(
+      'commaPosition: before does not work when tabs are used for indentation.'
+    );
+  }
+
+  if (cfg.params && !validateParams(cfg.params)) {
+    // eslint-disable-next-line no-console
+    console.warn('WARNING: All "params" option values should be strings.');
+  }
+
+  return cfg;
+}
+
+function validateParams(params: ParamItems | string[]): boolean {
+  const paramValues = params instanceof Array ? params : Object.values(params);
+  return paramValues.every(p => typeof p === 'string');
+}

--- a/test/sqlFormatter.test.ts
+++ b/test/sqlFormatter.test.ts
@@ -1,7 +1,6 @@
 import dedent from 'dedent-js';
 
-import { format, formatDialect, SqlLanguage } from '../src/sqlFormatter.js';
-import { sqlite } from '../src/languages/sqlite/sqlite.formatter.js';
+import { format, formatDialect, SqlLanguage, sqlite } from '../src/index.js';
 
 describe('sqlFormatter', () => {
   it('throws error when unsupported language parameter specified', () => {

--- a/test/sqlFormatter.test.ts
+++ b/test/sqlFormatter.test.ts
@@ -1,6 +1,6 @@
 import dedent from 'dedent-js';
 
-import { format, SqlLanguage } from '../src/sqlFormatter.js';
+import { format, formatDialect, SqlLanguage } from '../src/sqlFormatter.js';
 import { sqlite } from '../src/languages/sqlite/sqlite.formatter.js';
 
 describe('sqlFormatter', () => {
@@ -56,11 +56,13 @@ describe('sqlFormatter', () => {
     }).toThrow('aliasAs config is no more supported.');
   });
 
-  it('allows passing Dialect config object as a language parameter', () => {
-    expect(format('SELECT [foo], `bar`;', { language: sqlite })).toBe(dedent`
-      SELECT
-        [foo],
-        \`bar\`;
-    `);
+  describe('formatDialect()', () => {
+    it('allows passing Dialect config object as a dialect parameter', () => {
+      expect(formatDialect('SELECT [foo], `bar`;', { dialect: sqlite })).toBe(dedent`
+        SELECT
+          [foo],
+          \`bar\`;
+      `);
+    });
   });
 });


### PR DESCRIPTION
New API for supporting import of a single dialect. As discussed in #484, I've added a separate formatting function that works a bit differently than the old one.

The old `format()` function works like before, with the exception that `language` parameter can only be string:

```ts
import { format } from "sql-formatter";

format("SELECT *", { language: "mysql" });
```

The new `formatDialect()` only works with explicitly imported dialect:

```ts
import { formatDialect, mysql } from "sql-formatter";

formatDialect("SELECT *", { dialect: mysql });
```

`formatDialect()` is also used under the hood by the old `format()` function.

I chose to name it `formatDialect` to make it clear that it accepts a `dialect` config option (instead of `language`). This also aligns with the naming of types, where the actual value is a `DialectOptions` object. (Originally I thought of using `language` option for both, but this seemed too confusing - an option expecting one type in one context and another type in another context - so I opted for clearly distinct option names).

Fixes #452 