### PR TITLE
Add support for custom quote types

### DIFF
--- a/src/lexer/TokenizerOptions.ts
+++ b/src/lexer/TokenizerOptions.ts
@@ -22,13 +22,13 @@ export interface PrefixedQuoteType {
   requirePrefix?: boolean; // True when prefix is required
 }
 
-export type QuoteType = PlainQuoteType | PrefixedQuoteType;
-
-export interface VariableRegex {
+export interface RegexPattern {
   regex: string;
 }
 
-export type VariableType = VariableRegex | PrefixedQuoteType;
+export type QuoteType = PlainQuoteType | PrefixedQuoteType | RegexPattern;
+
+export type VariableType = RegexPattern | PrefixedQuoteType;
 
 export interface ParamTypes {
   // True to allow for positional "?" parameter placeholders

--- a/src/lexer/regexFactory.ts
+++ b/src/lexer/regexFactory.ts
@@ -127,6 +127,8 @@ export const quotePatterns = {
 const singleQuotePattern = (quoteTypes: QuoteType): string => {
   if (typeof quoteTypes === 'string') {
     return quotePatterns[quoteTypes];
+  } else if ('regex' in quoteTypes) {
+    return quoteTypes.regex;
   } else {
     return prefixesPattern(quoteTypes) + quotePatterns[quoteTypes.quote];
   }


### PR DESCRIPTION
Similarly to how variable types can be specified with a regex string, a string (and identifier) can now also be specified the same way.

Fixes #503 