### PR TITLE
Export ConfigError class as value, not as type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { supportedDialects, format, formatDialect } from './sqlFormatter.js';
 export { expandPhrases } from './expandPhrases.js';
+export { ConfigError } from './validateConfig.js';
 
 // Intentionally use "export *" syntax here to make sure when adding a new SQL dialect
 // we wouldn't forget to expose it in our public API.
@@ -20,4 +21,3 @@ export type {
   FormatOptions,
 } from './FormatOptions.js';
 export type { DialectOptions } from './dialect.js';
-export type { ConfigError } from './validateConfig.js';


### PR DESCRIPTION
I mistakenly had changed this to type-only export, but for classes we don't want to export only the type.

That broke the demo page that wants to access this class.

Fixes #521