### PR TITLE
Fix formatting of ON CONFLICT clause

### DIFF
--- a/src/languages/mariadb/mariadb.formatter.ts
+++ b/src/languages/mariadb/mariadb.formatter.ts
@@ -92,7 +92,6 @@ const onelineClauses = expandPhrases([
   'CREATE USER',
   'DEALLOCATE PREPARE',
   'DESCRIBE',
-  'DO',
   'DROP DATABASE',
   'DROP EVENT',
   'DROP FUNCTION',

--- a/src/languages/mysql/mysql.formatter.ts
+++ b/src/languages/mysql/mysql.formatter.ts
@@ -87,7 +87,6 @@ const onelineClauses = expandPhrases([
   'CREATE USER',
   'DEALLOCATE PREPARE',
   'DESCRIBE',
-  'DO',
   'DROP DATABASE',
   'DROP EVENT',
   'DROP FUNCTION',

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -150,7 +150,6 @@ const onelineClauses = expandPhrases([
   'DEALLOCATE',
   'DECLARE',
   'DISCARD',
-  'DO',
   'DROP ACCESS METHOD',
   'DROP AGGREGATE',
   'DROP CAST',

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -36,6 +36,8 @@ const onelineClauses = expandPhrases([
   // - update:
   'UPDATE [ONLY]',
   'WHERE CURRENT OF',
+  // - insert:
+  'ON CONFLICT',
   // - delete:
   'DELETE FROM [ONLY]',
   // - drop table:

--- a/src/languages/singlestoredb/singlestoredb.formatter.ts
+++ b/src/languages/singlestoredb/singlestoredb.formatter.ts
@@ -89,7 +89,6 @@ const onelineClauses = expandPhrases([
   'DESCRIBE',
   'DETACH DATABASE',
   'DETACH PIPELINE',
-  'DO',
   'DROP DATABASE',
   'DROP FUNCTION',
   'DROP INDEX',

--- a/src/languages/sqlite/sqlite.formatter.ts
+++ b/src/languages/sqlite/sqlite.formatter.ts
@@ -32,6 +32,8 @@ const reservedClauses = expandPhrases([
 const onelineClauses = expandPhrases([
   // - update:
   'UPDATE [OR ABORT | OR FAIL | OR IGNORE | OR REPLACE | OR ROLLBACK]',
+  // - insert:
+  'ON CONFLICT',
   // - delete:
   'DELETE FROM',
   // - drop table:

--- a/test/behavesLikeMariaDbFormatter.ts
+++ b/test/behavesLikeMariaDbFormatter.ts
@@ -116,14 +116,4 @@ export default function behavesLikeMariaDbFormatter(format: FormatFn) {
         (2, 'Dog');
     `);
   });
-
-  // Regression test for issue #535
-  it('gracefully handles ON CONFLICT .. DO syntax', () => {
-    expect(format(`INSERT INTO tbl VALUES (1,'Blah') ON CONFLICT DO NOTHING;`)).toBe(dedent`
-      INSERT INTO
-        tbl
-      VALUES
-        (1, 'Blah') ON CONFLICT DO NOTHING;
-    `);
-  });
 }

--- a/test/behavesLikeMariaDbFormatter.ts
+++ b/test/behavesLikeMariaDbFormatter.ts
@@ -116,4 +116,14 @@ export default function behavesLikeMariaDbFormatter(format: FormatFn) {
         (2, 'Dog');
     `);
   });
+
+  // Regression test for issue #535
+  it('gracefully handles ON CONFLICT .. DO syntax', () => {
+    expect(format(`INSERT INTO tbl VALUES (1,'Blah') ON CONFLICT DO NOTHING;`)).toBe(dedent`
+      INSERT INTO
+        tbl
+      VALUES
+        (1, 'Blah') ON CONFLICT DO NOTHING;
+    `);
+  });
 }

--- a/test/features/onConflict.ts
+++ b/test/features/onConflict.ts
@@ -1,0 +1,16 @@
+import dedent from 'dedent-js';
+
+import { FormatFn } from '../../src/sqlFormatter.js';
+
+export default function supportsOnConflict(format: FormatFn) {
+  // Regression test for issue #535
+  it('supports INSERT .. ON CONFLICT syntax', () => {
+    expect(format(`INSERT INTO tbl VALUES (1,'Blah') ON CONFLICT DO NOTHING;`)).toBe(dedent`
+      INSERT INTO
+        tbl
+      VALUES
+        (1, 'Blah')
+      ON CONFLICT DO NOTHING;
+    `);
+  });
+}

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -25,6 +25,7 @@ import supportsInsertInto from './features/insertInto.js';
 import supportsUpdate from './features/update.js';
 import supportsTruncateTable from './features/truncateTable.js';
 import supportsCreateView from './features/createView.js';
+import supportsOnConflict from './features/onConflict.js';
 
 describe('PostgreSqlFormatter', () => {
   const language = 'postgresql';
@@ -45,6 +46,7 @@ describe('PostgreSqlFormatter', () => {
   });
   supportsDeleteFrom(format);
   supportsInsertInto(format);
+  supportsOnConflict(format);
   supportsUpdate(format, { whereCurrentOf: true });
   supportsTruncateTable(format, { withoutTable: true });
   supportsStrings(format, ["''-qq", "U&''", "X''", "B''"]);

--- a/test/sqlite.test.ts
+++ b/test/sqlite.test.ts
@@ -21,6 +21,7 @@ import supportsLimiting from './features/limiting.js';
 import supportsInsertInto from './features/insertInto.js';
 import supportsUpdate from './features/update.js';
 import supportsCreateView from './features/createView.js';
+import supportsOnConflict from './features/onConflict.js';
 
 describe('SqliteFormatter', () => {
   const language = 'sqlite';
@@ -40,6 +41,7 @@ describe('SqliteFormatter', () => {
   });
   supportsDeleteFrom(format);
   supportsInsertInto(format);
+  supportsOnConflict(format);
   supportsUpdate(format);
   supportsStrings(format, ["''-qq", "X''"]);
   supportsIdentifiers(format, [`""-qq`, '``', '[]']);


### PR DESCRIPTION
In PostgreSQL and SQLite.

Also eliminate the `DO` keyword from onelineClauses list in every dialect.

Fixes #535 