### PR TITLE
Added pre-commit integration.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: sql-formatter
+    name: sql-formatter
+    description: "Reformat SQL files with sql-formatter"
+    entry: sql-formatter
+    language: node
+    types: [sql]
+    args: [--fix]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,6 @@
 -   id: sql-formatter
     name: sql-formatter
     description: "Reformat SQL files with sql-formatter"
-    entry: sql-formatter
+    entry: sql-formatter --fix
     language: node
     types: [sql]
-    args: [--fix]


### PR DESCRIPTION
This PR introduces direct [pre-commit](https://pre-commit.com/) compatibility.

Here is an example of how it can be integrated after it will be integrated:
```
repos:
-   repo: https://github.com/sql-formatter-org/sql-formatter
    rev: ''
    hooks:
    -   id: sql-formatter
```

Right now you need to create a separate repository in order to be able to integrate with `sql-formatter`.
Like this one: https://github.com/slyapustin/pre-commit-sql-formatter 