### PR TITLE
Allow BETWEEN operator to be followed by AND operator

### DIFF
--- a/test/features/between.ts
+++ b/test/features/between.ts
@@ -29,4 +29,13 @@ export default function supportsBetween(format: FormatFn) {
       END AND 3
     `);
   });
+
+  // Regression test for #534
+  it('supports AND after BETWEEN', () => {
+    expect(format('SELECT foo BETWEEN 1 AND 2 AND x > 10')).toBe(dedent`
+      SELECT
+        foo BETWEEN 1 AND 2
+        AND x > 10
+    `);
+  });
 }


### PR DESCRIPTION
Fixes a long-standing bug which resulted in ambiguous grammar.

The solution involves adding multiple new parser rules which exclude the AND/OR/XOR operators from expressions inside the BETWEEN-expression.

This solution is far from elegant. Really it's plain ugly, but at least it gets the bug fixed. I think there's no good way to fix it in the current parser/formatter architecture.

Fixes #534