### PR TITLE
Add FOR UPDATE clause support for Postgres

### DIFF
--- a/src/languages/plsql/plsql.formatter.ts
+++ b/src/languages/plsql/plsql.formatter.ts
@@ -17,7 +17,7 @@ const reservedClauses = expandPhrases([
   'ORDER [SIBLINGS] BY',
   'OFFSET',
   'FETCH {FIRST | NEXT}',
-  'FOR UPDATE',
+  'FOR UPDATE [OF]',
   // Data manipulation
   // - insert:
   'INSERT [INTO | ALL INTO]',

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -18,6 +18,7 @@ const reservedClauses = expandPhrases([
   'LIMIT',
   'OFFSET',
   'FETCH {FIRST | NEXT}',
+  'FOR {UPDATE | NO KEY UPDATE | SHARE | KEY SHARE} [OF]',
   // Data manipulation
   // - insert:
   'INSERT INTO',

--- a/test/plsql.test.ts
+++ b/test/plsql.test.ts
@@ -159,8 +159,8 @@ describe('PlSqlFormatter', () => {
         *
       FROM
         tbl
-      FOR UPDATE
-        OF tbl.salary;
+      FOR UPDATE OF
+        tbl.salary;
     `);
   });
 });

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -263,7 +263,7 @@ describe('PostgreSqlFormatter', () => {
     `);
   });
 
-  it('formats FOR UPDATE clauses', () => {
+  it('formats FOR UPDATE clause', () => {
     expect(
       format(`
         SELECT * FROM tbl FOR UPDATE;

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -267,7 +267,7 @@ describe('PostgreSqlFormatter', () => {
     expect(
       format(`
         SELECT * FROM tbl FOR UPDATE;
-        SELECT * FROM tbl FOR UPDATE OF tbl.a;
+        SELECT * FROM tbl FOR UPDATE OF tbl.salary;
       `)
     ).toBe(dedent`
       SELECT
@@ -281,7 +281,7 @@ describe('PostgreSqlFormatter', () => {
       FROM
         tbl
       FOR UPDATE OF
-        tbl.a;
+        tbl.salary;
     `);
   });
 });

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -262,4 +262,26 @@ describe('PostgreSqlFormatter', () => {
       DROP NOT NULL;
     `);
   });
+
+  it('formats FOR UPDATE clauses', () => {
+    expect(
+      format(`
+        SELECT * FROM tbl FOR UPDATE;
+        SELECT * FROM tbl FOR UPDATE OF tbl.a;
+      `)
+    ).toBe(dedent`
+      SELECT
+        *
+      FROM
+        tbl
+      FOR UPDATE;
+
+      SELECT
+        *
+      FROM
+        tbl
+      FOR UPDATE OF
+        tbl.a;
+    `);
+  });
 });


### PR DESCRIPTION
Like #421, but for Postgres.

IMO things look better if `OF` (if present) is placed on the same like as `FOR ...` and any specific columns are placed on a separate line. I make this change for PL/SQL as well, but I'd be happy to revert that if you feel differently.