### PR TITLE
Fix comma position before

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ For those who have admin access on the repo, the new release publish flow is as 
 - Sasha Aliashkevich <olsender@gmail.com>
 - Sean Song <mail@seansong.dev>
 - Sergei Egorov <sergei.egorov@zeroturnaround.com>
-- Stanislav Germanovskii <s.germanovskiy@tinkoff.ru>
+- Stanislav Germanovskii <stanislav.germanovskii@gmail.com>
 - Steven Yung <stevenyung@fastmail.com>
 - Tito Griné <tgrine@singlestore.com>
 - Toliver <teejae@gmail.com>

--- a/src/formatter/formatCommaPositions.ts
+++ b/src/formatter/formatCommaPositions.ts
@@ -3,6 +3,13 @@ import { maxLength } from '../utils.js';
 
 const PRECEDING_WHITESPACE_REGEX = /^\s+/u;
 
+export interface Line {
+  originalContent: string;
+  commentAtLineStart: string;
+  content: string;
+  commentAtLineEnd: string;
+}
+
 /**
  * Handles comma placement - either before, after or tabulated
  */
@@ -11,10 +18,11 @@ export default function formatCommaPositions(
   commaPosition: CommaPosition,
   indent: string
 ): string {
-  return groupCommaDelimitedLines(query.split('\n'))
+  const lines = splitContentAndComments(query);
+  return groupCommaDelimitedLines(lines)
     .flatMap(commaLines => {
       if (commaLines.length === 1) {
-        return commaLines;
+        return commaLines[0].originalContent;
       } else if (commaPosition === 'tabular') {
         return formatTabular(commaLines);
       } else if (commaPosition === 'before') {
@@ -40,20 +48,50 @@ export default function formatCommaPositions(
  * Returns groups like this:
  *
  *     [
- *       ['SELECT'],
- *       ['  foo,', '  bar, --comment', '  baz'],
- *       ['FROM']
+ *       [{
+ *        originalContent: 'SELECT',
+ *        commentAtLineStart: '',
+ *        content: 'SELECT',
+ *        commentAtLineEnd: '',
+ *       }],
+ *       [{
+ *         originalContent: '  foo,',
+ *         commentAtLineStart: '',
+ *         content: '  foo,',
+ *         commentAtLineEnd: '',
+ *       }, {
+ *         originalContent: '  bar, --comment',
+ *         commentAtLineStart: '  ',
+ *         content: 'bar,',
+ *         commentAtLineEnd: '--comment',
+ *       }, {
+ *         originalContent: '  baz',
+ *         commentAtLineStart: '  ',
+ *         content: 'baz',
+ *         commentAtLineEnd: '',
+ *       }],
+ *       {
+ *         originalContent: 'FROM',
+ *         commentAtLineStart: '',
+ *         content: 'FROM',
+ *         commentAtLineEnd: '',
+ *       }
  *     ]
  */
-function groupCommaDelimitedLines(lines: string[]): string[][] {
-  const groups: string[][] = [];
+function groupCommaDelimitedLines(lines: Line[]): Line[][] {
+  const groups: Line[][] = [];
   for (let i = 0; i < lines.length; i++) {
     const group = [lines[i]];
     // when line ends with comma,
     // gather together all following lines that also end with comma,
     // plus one (which doesn't end with comma)
-    while (lines[i].match(/^[^--]*,(\s*(--.*)?$)/)) {
+    while (lines[i].content.match(/.*,/)) {
       i++;
+      // handle comment before next meanful line
+      while (lines[i].content.length === 0) {
+        group.push(lines[i]);
+        i++;
+      }
       group.push(lines[i]);
     }
     groups.push(group);
@@ -62,34 +100,43 @@ function groupCommaDelimitedLines(lines: string[]): string[][] {
 }
 
 // makes all lines the same length by appending spaces before comma
-function formatTabular(commaLines: string[]): string[] {
-  const commaPosition = maxLength(trimTrailingComments(commaLines)) - 1;
+function formatTabular(commaLines: Line[]): string[] {
+  const commaPosition = maxLength(commaLines.map(line => trimTrailingCommas(line.content)));
+
   return commaLines.map((line, i) => {
     if (i === commaLines.length - 1) {
-      return line; // do not add comma for last item
+      return line.originalContent; // do not add comma for last item
     }
     return indentComma(line, commaPosition);
   });
 }
 
-function indentComma(line: string, commaPosition: number) {
-  const [, code, comment] = line.match(/^(.*?),(\s*--.*)?$/) || [];
+function indentComma(line: Line, commaPosition: number) {
+  const lineContent = trimTrailingCommas(line.content);
 
-  const spaces = ' '.repeat(commaPosition - code.length);
-  return `${code}${spaces},${comment ?? ''}`;
+  const spaces = ' '.repeat(
+    Math.max(commaPosition - lineContent.length - line.commentAtLineStart.length, 0)
+  );
+  const commentAtLineEnd = line.commentAtLineEnd.length ? ' ' + line.commentAtLineEnd : '';
+  return `${line.commentAtLineStart}${lineContent}${spaces},${commentAtLineEnd}`;
 }
 
-function formatBefore(commaLines: string[], indent: string): string[] {
-  return trimTrailingCommas(commaLines)
+function formatBefore(commaLines: Line[], indent: string): string[] {
+  return commaLines
     .map((line, i) => {
-      if (i === 0) {
-        return line; // do not add comma for first item
+      if (line.content === '') {
+        return line.originalContent;
       }
-      const [whitespace] = line.match(PRECEDING_WHITESPACE_REGEX) || [''];
+      const lineContent = trimTrailingCommas(line.content);
+      const commentAtLineEnd = line.commentAtLineEnd.length ? ' ' + line.commentAtLineEnd : '';
+      if (i === 0) {
+        return `${line.commentAtLineStart}${lineContent}${commentAtLineEnd}`; // do not add comma for first item
+      }
+      const [whitespace] = line.content.match(PRECEDING_WHITESPACE_REGEX) || [''];
       return (
         removeLastIndent(whitespace, indent) +
         indent.replace(/ {2}$/, ', ') + // add comma to the end of last indent
-        line.trimStart()
+        `${line.commentAtLineStart}${lineContent.trimStart()}${commentAtLineEnd}`
       );
     })
     .filter(line => line !== '');
@@ -99,10 +146,130 @@ function removeLastIndent(whitespace: string, indent: string): string {
   return whitespace.replace(new RegExp(indent + '$'), '');
 }
 
-function trimTrailingCommas(lines: string[]): string[] {
-  return lines.map(line => line.replace(/,(\s*(--.*)?$)/, '$1'));
+function trimTrailingCommas(lineContent: string): string {
+  return lineContent.replace(/,\s*$/, '');
 }
 
-function trimTrailingComments(lines: string[]): string[] {
-  return lines.map(line => line.replace(/\s*--.*/, ''));
+const sqlCommentRegexp = /--(?!.*").*$/gm;
+const sqlMultiLineCommentRegexp = /\/\*[\s\S]*?\*\//gm;
+
+function mergeRanges(ranges: { start: number; end: number }[]) {
+  const mergedRanges = [] as { start: number; end: number }[];
+  let currentRange = null as { start: number; end: number } | null;
+
+  for (let i = 0; i < ranges.length; ++i) {
+    const range = ranges[i];
+    if (currentRange === null) {
+      currentRange = range;
+    } else if (range.start <= currentRange.end) {
+      currentRange.end = Math.max(currentRange.end, range.end);
+    } else {
+      mergedRanges.push(currentRange);
+      currentRange = range;
+    }
+  }
+
+  if (currentRange !== null) {
+    mergedRanges.push(currentRange);
+  }
+
+  return mergedRanges;
+}
+
+export function getCommentsRanges(content: string) {
+  const ranges = [] as { start: number; end: number }[];
+
+  const matches = [
+    ...content.matchAll(sqlCommentRegexp),
+    ...content.matchAll(sqlMultiLineCommentRegexp),
+  ];
+
+  for (let i = 0; i < matches.length; ++i) {
+    const { index } = matches[i];
+    if (index !== undefined && index !== null) {
+      ranges.push({ start: index, end: index + matches[i][0].length });
+    }
+  }
+
+  return mergeRanges(ranges.sort((a, b) => a.start - b.start));
+}
+
+export function queryToLinesWithIndexes(query: string) {
+  const lines = [] as { content: string; lineNumber: number; start: number }[];
+  let lineNumber = 1;
+  let currentLineContent = '';
+  let currentLineStart = 0;
+
+  for (let i = 0; i < query.length; i++) {
+    if (query[i] === '\n') {
+      lines.push({
+        content: currentLineContent,
+        lineNumber,
+        start: currentLineStart,
+      });
+      lineNumber++;
+      currentLineContent = '';
+      currentLineStart = i + 1;
+    } else {
+      currentLineContent += query[i];
+    }
+  }
+  if (currentLineContent !== '') {
+    lines.push({
+      content: currentLineContent,
+      lineNumber,
+      start: currentLineStart,
+    });
+  }
+
+  return lines;
+}
+
+export function splitContentAndComments(query: string) {
+  const lines = queryToLinesWithIndexes(query.trim());
+  const commentsRanges = getCommentsRanges(query);
+
+  return lines.map(line => {
+    const lineContent = line.content;
+    const lineStart = line.start;
+
+    const isWholeLineComment = commentsRanges.some(
+      range => range.start <= lineStart && range.end >= lineStart + lineContent.length - 1
+    );
+    if (isWholeLineComment) {
+      return {
+        commentAtLineStart: lineContent,
+        content: '',
+        commentAtLineEnd: '',
+        originalContent: lineContent,
+      };
+    }
+
+    const commentRangeAtLineStart = commentsRanges.find(
+      range => range.start <= lineStart && range.end >= lineStart
+    );
+    const commentRangeAtLineEnd = commentsRanges.find(
+      range => range.start >= lineStart && range.end >= lineStart + lineContent.length
+    );
+
+    const commentAtLineStart = commentRangeAtLineStart
+      ? lineContent.slice(0, commentRangeAtLineStart.end - lineStart)
+      : '';
+    const commentAtLineEnd = commentRangeAtLineEnd
+      ? lineContent.slice(commentRangeAtLineEnd.start - lineStart)
+      : '';
+    const content = lineContent
+      .slice(
+        commentRangeAtLineStart ? commentRangeAtLineStart.end - lineStart : 0,
+        commentRangeAtLineEnd ? commentRangeAtLineEnd.start - lineStart : lineContent.length
+      )
+      .trimEnd();
+
+    return {
+      commentAtLineStart,
+      content,
+      commentAtLineEnd,
+      originalContent: lineContent,
+    };
+  }) as Line[];
 }

--- a/src/formatter/formatCommaPositions.ts
+++ b/src/formatter/formatCommaPositions.ts
@@ -52,7 +52,7 @@ function groupCommaDelimitedLines(lines: string[]): string[][] {
     // when line ends with comma,
     // gather together all following lines that also end with comma,
     // plus one (which doesn't end with comma)
-    while (lines[i].match(/.*,(\s*(--.*)?$)/)) {
+    while (lines[i].match(/^[^--]*,(\s*(--.*)?$)/)) {
       i++;
       group.push(lines[i]);
     }
@@ -80,17 +80,19 @@ function indentComma(line: string, commaPosition: number) {
 }
 
 function formatBefore(commaLines: string[], indent: string): string[] {
-  return trimTrailingCommas(commaLines).map((line, i) => {
-    if (i === 0) {
-      return line; // do not add comma for first item
-    }
-    const [whitespace] = line.match(PRECEDING_WHITESPACE_REGEX) || [''];
-    return (
-      removeLastIndent(whitespace, indent) +
-      indent.replace(/ {2}$/, ', ') + // add comma to the end of last indent
-      line.trimStart()
-    );
-  });
+  return trimTrailingCommas(commaLines)
+    .map((line, i) => {
+      if (i === 0) {
+        return line; // do not add comma for first item
+      }
+      const [whitespace] = line.match(PRECEDING_WHITESPACE_REGEX) || [''];
+      return (
+        removeLastIndent(whitespace, indent) +
+        indent.replace(/ {2}$/, ', ') + // add comma to the end of last indent
+        line.trimStart()
+      );
+    })
+    .filter(line => line !== '');
 }
 
 function removeLastIndent(whitespace: string, indent: string): string {

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -274,4 +274,25 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
       `);
     });
   }
+
+  it('should handle comma in comments with comaPosition:before', () => {
+    const result = format(
+      `
+      SELECT
+        a -- comment with -- ,
+        --, b
+        , c
+      FROM T1
+    `,
+      { commaPosition: 'before' }
+    );
+    expect(result).toBe(dedent`
+      SELECT
+        a -- comment with -- ,
+        --, b
+      , c
+      FROM
+        T1
+    `);
+  });
 }

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -274,26 +274,4 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
       `);
     });
   }
-
-  it('should handle comma in comments with comaPosition:before', () => {
-    const result = format(
-      `
-        SELECT
-          a, -- comment with -- ,
-          --, b
-          c
-        FROM
-          T1
-    `,
-      { commaPosition: 'before' }
-    );
-    expect(result).toBe(dedent`
-      SELECT
-        a -- comment with -- ,
-        --, b
-      , c
-      FROM
-        T1
-    `);
-  });
 }

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -278,11 +278,12 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
   it('should handle comma in comments with comaPosition:before', () => {
     const result = format(
       `
-      SELECT
-        a -- comment with -- ,
-        --, b
-        , c
-      FROM T1
+        SELECT
+          a, -- comment with -- ,
+          --, b
+          c
+        FROM
+          T1
     `,
       { commaPosition: 'before' }
     );

--- a/test/options/commaPosition.ts
+++ b/test/options/commaPosition.ts
@@ -361,5 +361,27 @@ export default function supportsCommaPosition(format: FormatFn) {
         },
       ]);
     });
+
+    it('should handle comma in comments with comaPosition:before', () => {
+      const result = format(
+        `
+        SELECT
+          a, -- comment with -- ,
+          --, b
+          c
+        FROM
+          T1
+    `,
+        { commaPosition: 'before' }
+      );
+      expect(result).toBe(dedent`
+      SELECT
+        a -- comment with -- ,
+        --, b
+      , c
+      FROM
+        T1
+    `);
+    });
   });
 }

--- a/test/options/commaPosition.ts
+++ b/test/options/commaPosition.ts
@@ -114,10 +114,10 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it('should work with multiline comment and with strings with --', () => {
+    it('should work with multiline comment and with strings with -- and ,', () => {
       const q = `
       SELECT
-        "5 -- 6" as col1, /*
+        "5 -- 6," as col1, /*
         as mycol
         */ 8 as col2,
         --, b
@@ -131,7 +131,7 @@ export default function supportsCommaPosition(format: FormatFn) {
       expect(result).toBe(
         dedent`
           SELECT
-              "5 -- 6" as col1
+              "5 -- 6," as col1
               /*
               as mycol
               */

--- a/test/options/commaPosition.ts
+++ b/test/options/commaPosition.ts
@@ -1,12 +1,16 @@
-import { expect } from '@jest/globals';
-import dedent from 'dedent-js';
+import { expect } from "@jest/globals";
+import dedent from "dedent-js";
 
-import { FormatFn } from '../../src/sqlFormatter.js';
+import { FormatFn } from "../../src/sqlFormatter.js";
+import {
+  getCommentsRanges,
+  queryToLinesWithIndexes, splitContentAndComments
+} from '../../src/formatter/formatCommaPositions.js';
 
 export default function supportsCommaPosition(format: FormatFn) {
-  it('defaults to comma after column', () => {
+  it("defaults to comma after column", () => {
     const result = format(
-      'SELECT alpha , MAX(beta) , delta AS d ,epsilon FROM gamma GROUP BY alpha , delta, epsilon'
+      "SELECT alpha , MAX(beta) , delta AS d ,epsilon FROM gamma GROUP BY alpha , delta, epsilon"
     );
     expect(result).toBe(
       dedent`
@@ -25,11 +29,11 @@ export default function supportsCommaPosition(format: FormatFn) {
     );
   });
 
-  describe('commaPosition: before', () => {
-    it('adds comma before column', () => {
+  describe("commaPosition: before", () => {
+    it("adds comma before column", () => {
       const result = format(
-        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
-        { commaPosition: 'before' }
+        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
+        { commaPosition: "before" }
       );
       expect(result).toBe(
         dedent`
@@ -48,12 +52,12 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it('handles comments after commas', () => {
+    it("handles comments after commas", () => {
       const result = format(
         `SELECT alpha, --comment1
         MAX(beta), --comment2
         delta AS d, epsilon --comment3`,
-        { commaPosition: 'before' }
+        { commaPosition: "before" }
       );
       expect(result).toBe(
         dedent`
@@ -66,10 +70,10 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it('works with larger indent', () => {
+    it("works with larger indent", () => {
       const result = format(
-        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
-        { commaPosition: 'before', tabWidth: 4 }
+        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
+        { commaPosition: "before", tabWidth: 4 }
       );
       expect(result).toBe(
         dedent`
@@ -88,12 +92,69 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
+    it('should work with multiline comment between column and comma', () => {
+      const result = format(
+        'SELECT alpha, MAX(beta) /* as b */, delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
+        { commaPosition: 'before', tabWidth: 4 }
+      );
+      expect(result).toBe(
+        dedent`
+          SELECT
+              alpha
+            , MAX(beta) /* as b */
+            , delta AS d
+            , epsilon
+          FROM
+              gamma
+          GROUP BY
+              alpha
+            , delta
+            , epsilon
+        `
+      );
+    });
+
+    it('should work with multiline comment and with strings with --', () => {
+      const q = `
+      SELECT
+        "5 -- 6" as col1, /*
+        as mycol
+        */ 8 as col2,
+        --, b
+        c
+      FROM T1
+      WHERE /*
+        c > 20 and
+      */ c < 100
+    `.trim();
+      const result = format(q, { commaPosition: 'before', tabWidth: 4 });
+      expect(result).toBe(
+        dedent`
+          SELECT
+              "5 -- 6" as col1
+              /*
+              as mycol
+              */
+            , 8 as col2
+              --, b
+            , c
+          FROM
+              T1
+          WHERE
+              /*
+              c > 20 and
+              */
+              c < 100
+        `
+      );
+    });
+
     // This style is fundamentally incompatible with tabs
-    it('throws error when tabs used for indentation', () => {
+    it("throws error when tabs used for indentation", () => {
       expect(() => {
-        format('SELECT alpha, MAX(beta), delta AS d, epsilon', {
-          commaPosition: 'before',
-          useTabs: true,
+        format("SELECT alpha, MAX(beta), delta AS d, epsilon", {
+          commaPosition: "before",
+          useTabs: true
         });
       }).toThrowErrorMatchingInlineSnapshot(
         `"commaPosition: before does not work when tabs are used for indentation."`
@@ -101,11 +162,11 @@ export default function supportsCommaPosition(format: FormatFn) {
     });
   });
 
-  describe('commaPosition: tabular', () => {
-    it('aligns commas to a column', () => {
+  describe("commaPosition: tabular", () => {
+    it("aligns commas to a column", () => {
       const result = format(
-        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
-        { commaPosition: 'tabular' }
+        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
+        { commaPosition: "tabular" }
       );
       expect(result).toBe(
         dedent`
@@ -124,13 +185,13 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it('handles comments after commas', () => {
+    it("handles comments after commas", () => {
       const result = format(
         `SELECT alpha, --comment1
         beta,--comment2
         delta, epsilon,--comment3
         iota --comment4`,
-        { commaPosition: 'tabular' }
+        { commaPosition: "tabular" }
       );
       expect(result).toBe(
         dedent`
@@ -144,10 +205,10 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it('is not effected by indent size', () => {
+    it("is not effected by indent size", () => {
       const result = format(
-        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
-        { commaPosition: 'tabular', tabWidth: 6 }
+        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
+        { commaPosition: "tabular", tabWidth: 6 }
       );
       expect(result).toBe(
         dedent`
@@ -166,10 +227,10 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it('handles tabs', () => {
-      const result = format('SELECT alpha, MAX(beta), delta AS d, epsilon', {
-        commaPosition: 'tabular',
-        useTabs: true,
+    it("handles tabs", () => {
+      const result = format("SELECT alpha, MAX(beta), delta AS d, epsilon", {
+        commaPosition: "tabular",
+        useTabs: true
       });
       expect(result).toBe(
         dedent`
@@ -180,6 +241,125 @@ export default function supportsCommaPosition(format: FormatFn) {
           \tepsilon
         `
       );
+    });
+
+    it('should prepare array of comment ranges ordered by start', () => {
+      expect(
+        getCommentsRanges(`SELECT
+        5 - 6 as col1, -- comment with -- ,
+        8 as col2 /*
+        --, b
+        */ , c`)
+      ).toEqual([
+        { start: 30, end: 50 },
+        { start: 69, end: 96 },
+      ]);
+    });
+
+    it('should split query into lines objects', () => {
+      expect(
+        queryToLinesWithIndexes(`SELECT
+        5 - 6 as col1, -- comment with -- ,
+        8 as col2 /*
+        --, b
+        */ , c`)
+      ).toEqual([
+        {
+          content: 'SELECT',
+          lineNumber: 1,
+          start: 0,
+        },
+        {
+          content: '        5 - 6 as col1, -- comment with -- ,',
+          lineNumber: 2,
+          start: 7,
+        },
+        {
+          content: '        8 as col2 /*',
+          lineNumber: 3,
+          start: 51,
+        },
+        {
+          content: '        --, b',
+          lineNumber: 4,
+          start: 72,
+        },
+        {
+          content: '        */ , c',
+          lineNumber: 5,
+          start: 86,
+        },
+      ]);
+    });
+
+    it('should split content and comments and handle -- and /**/ comments', () => {
+      const q = `
+      SELECT
+        5 - 6 /* as mycol */ as col1, -- comment with -- ,
+        8 as col2
+        --, b
+        , c
+      FROM T1
+      WHERE /*
+        c > 20 and
+      */ c < 100
+    `.trim();
+      expect(splitContentAndComments(q)).toEqual([
+        {
+          content: 'SELECT',
+          commentAtLineStart: '',
+          commentAtLineEnd: '',
+          originalContent: 'SELECT',
+        },
+        {
+          content: '        5 - 6 /* as mycol */ as col1,',
+          commentAtLineStart: '',
+          commentAtLineEnd: '-- comment with -- ,',
+          originalContent: '        5 - 6 /* as mycol */ as col1, -- comment with -- ,',
+        },
+        {
+          content: '        8 as col2',
+          commentAtLineStart: '',
+          commentAtLineEnd: '',
+          originalContent: '        8 as col2',
+        },
+        {
+          content: '',
+          commentAtLineStart: '',
+          commentAtLineEnd: '--, b',
+          originalContent: '        --, b',
+        },
+        {
+          content: '        , c',
+          commentAtLineStart: '',
+          commentAtLineEnd: '',
+          originalContent: '        , c',
+        },
+        {
+          content: '      FROM T1',
+          commentAtLineStart: '',
+          commentAtLineEnd: '',
+          originalContent: '      FROM T1',
+        },
+        {
+          content: '      WHERE',
+          commentAtLineStart: '',
+          commentAtLineEnd: '/*',
+          originalContent: '      WHERE /*',
+        },
+        {
+          content: '',
+          commentAtLineStart: '        c > 20 and',
+          commentAtLineEnd: '',
+          originalContent: '        c > 20 and',
+        },
+        {
+          commentAtLineEnd: '',
+          commentAtLineStart: '      */',
+          content: ' c < 100',
+          originalContent: '      */ c < 100',
+        },
+      ]);
     });
   });
 }

--- a/test/options/commaPosition.ts
+++ b/test/options/commaPosition.ts
@@ -1,16 +1,17 @@
-import { expect } from "@jest/globals";
-import dedent from "dedent-js";
+import { expect } from '@jest/globals';
+import dedent from 'dedent-js';
 
-import { FormatFn } from "../../src/sqlFormatter.js";
+import { FormatFn } from '../../src/sqlFormatter.js';
 import {
   getCommentsRanges,
-  queryToLinesWithIndexes, splitContentAndComments
+  queryToLinesWithIndexes,
+  splitContentAndComments,
 } from '../../src/formatter/formatCommaPositions.js';
 
 export default function supportsCommaPosition(format: FormatFn) {
-  it("defaults to comma after column", () => {
+  it('defaults to comma after column', () => {
     const result = format(
-      "SELECT alpha , MAX(beta) , delta AS d ,epsilon FROM gamma GROUP BY alpha , delta, epsilon"
+      'SELECT alpha , MAX(beta) , delta AS d ,epsilon FROM gamma GROUP BY alpha , delta, epsilon'
     );
     expect(result).toBe(
       dedent`
@@ -29,11 +30,11 @@ export default function supportsCommaPosition(format: FormatFn) {
     );
   });
 
-  describe("commaPosition: before", () => {
-    it("adds comma before column", () => {
+  describe('commaPosition: before', () => {
+    it('adds comma before column', () => {
       const result = format(
-        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
-        { commaPosition: "before" }
+        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
+        { commaPosition: 'before' }
       );
       expect(result).toBe(
         dedent`
@@ -52,12 +53,12 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it("handles comments after commas", () => {
+    it('handles comments after commas', () => {
       const result = format(
         `SELECT alpha, --comment1
         MAX(beta), --comment2
         delta AS d, epsilon --comment3`,
-        { commaPosition: "before" }
+        { commaPosition: 'before' }
       );
       expect(result).toBe(
         dedent`
@@ -70,10 +71,10 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it("works with larger indent", () => {
+    it('works with larger indent', () => {
       const result = format(
-        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
-        { commaPosition: "before", tabWidth: 4 }
+        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
+        { commaPosition: 'before', tabWidth: 4 }
       );
       expect(result).toBe(
         dedent`
@@ -150,11 +151,11 @@ export default function supportsCommaPosition(format: FormatFn) {
     });
 
     // This style is fundamentally incompatible with tabs
-    it("throws error when tabs used for indentation", () => {
+    it('throws error when tabs used for indentation', () => {
       expect(() => {
-        format("SELECT alpha, MAX(beta), delta AS d, epsilon", {
-          commaPosition: "before",
-          useTabs: true
+        format('SELECT alpha, MAX(beta), delta AS d, epsilon', {
+          commaPosition: 'before',
+          useTabs: true,
         });
       }).toThrowErrorMatchingInlineSnapshot(
         `"commaPosition: before does not work when tabs are used for indentation."`
@@ -162,11 +163,11 @@ export default function supportsCommaPosition(format: FormatFn) {
     });
   });
 
-  describe("commaPosition: tabular", () => {
-    it("aligns commas to a column", () => {
+  describe('commaPosition: tabular', () => {
+    it('aligns commas to a column', () => {
       const result = format(
-        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
-        { commaPosition: "tabular" }
+        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
+        { commaPosition: 'tabular' }
       );
       expect(result).toBe(
         dedent`
@@ -185,13 +186,13 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it("handles comments after commas", () => {
+    it('handles comments after commas', () => {
       const result = format(
         `SELECT alpha, --comment1
         beta,--comment2
         delta, epsilon,--comment3
         iota --comment4`,
-        { commaPosition: "tabular" }
+        { commaPosition: 'tabular' }
       );
       expect(result).toBe(
         dedent`
@@ -205,10 +206,10 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it("is not effected by indent size", () => {
+    it('is not effected by indent size', () => {
       const result = format(
-        "SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon",
-        { commaPosition: "tabular", tabWidth: 6 }
+        'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
+        { commaPosition: 'tabular', tabWidth: 6 }
       );
       expect(result).toBe(
         dedent`
@@ -227,10 +228,10 @@ export default function supportsCommaPosition(format: FormatFn) {
       );
     });
 
-    it("handles tabs", () => {
-      const result = format("SELECT alpha, MAX(beta), delta AS d, epsilon", {
-        commaPosition: "tabular",
-        useTabs: true
+    it('handles tabs', () => {
+      const result = format('SELECT alpha, MAX(beta), delta AS d, epsilon', {
+        commaPosition: 'tabular',
+        useTabs: true,
       });
       expect(result).toBe(
         dedent`


### PR DESCRIPTION
Fix adding additional line before lines started with ',' when comma position is "before".
Fix treating ',' in the end of comment as lines separator