### PR TITLE
fix: Update E style escape strings for postgresql

### DIFF
--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -266,7 +266,7 @@ export const postgresql: DialectOptions = {
     stringTypes: [
       '$$',
       { quote: "''-qq", prefixes: ['U&'] },
-      { quote: "''-bs", prefixes: ['E'], requirePrefix: true },
+      { quote: "''-qq-bs", prefixes: ['E'], requirePrefix: true },
       { quote: "''-raw", prefixes: ['B', 'X'], requirePrefix: true },
     ],
     identTypes: [{ quote: '""-qq', prefixes: ['U&'] }],

--- a/test/features/strings.ts
+++ b/test/features/strings.ts
@@ -12,6 +12,7 @@ type StringType =
   | "''-bs" // with backslash escaping
   | "U&''" // with repeated-quote escaping
   | "N''" // with escaping style depending on whether also ''-qq or ''-bs was specified
+  | "E''" // with escaping style depending on whether also ''-qq or ''-bs was specified
   | "X''" // no escaping
   | 'X""' // no escaping
   | "B''" // no escaping
@@ -136,6 +137,32 @@ export default function supportsStrings(format: FormatFn, stringTypes: StringTyp
 
     it("detects consecutive N'' strings as separate ones", () => {
       expect(format("N'foo'N'bar'")).toBe("N'foo' N'bar'");
+    });
+  }
+
+  if (stringTypes.includes("E''")) {
+    it('supports unicode strings', () => {
+      expect(format("SELECT E'where' FROM E'update'")).toBe(dedent`
+        SELECT
+          E'where'
+        FROM
+          E'update'
+      `);
+    });
+
+    if (stringTypes.includes("''-qq")) {
+      it("supports escaping in E'' strings with repeated quote", () => {
+        expect(format("E'foo '' JOIN bar'")).toBe("E'foo '' JOIN bar'");
+      });
+    }
+    if (stringTypes.includes("''-bs")) {
+      it("supports escaping in E'' strings with a backslash", () => {
+        expect(format("E'foo \\' JOIN bar'")).toBe("E'foo \\' JOIN bar'");
+      });
+    }
+
+    it("detects consecutive E'' strings as separate ones", () => {
+      expect(format("E'foo'E'bar'")).toBe("E'foo' E'bar'");
     });
   }
 

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -52,7 +52,7 @@ describe('PostgreSqlFormatter', () => {
   supportsOnConflict(format);
   supportsUpdate(format, { whereCurrentOf: true });
   supportsTruncateTable(format, { withoutTable: true });
-  supportsStrings(format, ["''-qq", "U&''", "X''", "B''"]);
+  supportsStrings(format, ["''-qq", "U&''", "X''", "B''", "E''"]);
   supportsIdentifiers(format, [`""-qq`, 'U&""']);
   supportsBetween(format);
   supportsSchema(format);


### PR DESCRIPTION
As described in the [wiki](https://github.com/sql-formatter-org/sql-formatter/wiki/strings), E style PostgreSQL strings support both backslash and double single quote escaping. Also added the additional test for E strings into the test util. 