### PR TITLE
Remove functions from keywordCase docs

### DIFF
--- a/docs/keywordCase.md
+++ b/docs/keywordCase.md
@@ -1,6 +1,6 @@
 # keywordCase
 
-Converts reserved keywords to upper or lowercase.
+Converts reserved keywords to upper- or lowercase.
 
 ## Options
 

--- a/docs/keywordCase.md
+++ b/docs/keywordCase.md
@@ -1,6 +1,6 @@
 # keywordCase
 
-Converts reserved keywords and builtin function names to upper or lowercase.
+Converts reserved keywords to upper or lowercase.
 
 ## Options
 


### PR DESCRIPTION
sql-formatter v15 included changes which excluded functions from keywordCase

- https://github.com/sql-formatter-org/sql-formatter/releases/tag/v15.0.0