### PR TITLE
Add primary key, generated column reserved phrases

### DIFF
--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -246,6 +246,8 @@ const reservedJoins = expandPhrases([
 ]);
 
 const reservedPhrases = expandPhrases([
+  'PRIMARY KEY',
+  'GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY',
   'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
   '{ROWS | RANGE | GROUPS} BETWEEN',
   // https://www.postgresql.org/docs/current/datatype-datetime.html


### PR DESCRIPTION
Add reserved phrases for PostgreSQL for primary keys and generated columns

After this change, the formatting results in the common style in the ecosystem:

```sql
CREATE TABLE animals (
  id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY
);
```

Before, the following configuration would result in the mixed lowercase for `KEY`, `GENERATED`, `ALWAYS`, and `IDENTITY`:

```sql
CREATE TABLE animals (
  id integer PRIMARY key generated always AS identity
);
```

Config (attempt to match style of official PostgreSQL docs):

```js
{
  language: 'postgresql',
  keywordCase: 'upper',
  identifierCase: 'lower',
  dataTypeCase: 'lower',
  functionCase: 'lower',
}
```

This was caused by the PostgreSQL keywords being removed in:

- https://github.com/sql-formatter-org/sql-formatter/issues/709