### PR TITLE
fix formatting of block quotes with **/ closing characters

### DIFF
--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -239,6 +239,12 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
     `);
   });
 
+  // Regression test for https://github.com/sql-formatter-org/sql-formatter/issues/747
+  it('handles block comments with /** and **/ patterns', () => {
+    const sql = `/** This is a block comment **/`;
+    expect(format(sql)).toBe(sql);
+  });
+
   if (opts.hashComments) {
     it('supports # line comment', () => {
       const result = format('SELECT alpha # commment\nFROM beta');


### PR DESCRIPTION
This is a common bug with Regex-based tokenizers. The previous regex was capturing too many characters in the "MIDDLE" regex, which was causing expressions like `/** comment **/` to be treated as individual operators instead of a comment.

The fix implemented here is to use a stack-based tokenizer which to parse nested comments instead. This appears to work as expected for TransactSQL dialects according to the [reference doc](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/slash-star-comment-transact-sql?view=sql-server-ver16). 

Closes https://github.com/sql-formatter-org/sql-formatter/issues/747