### PR TITLE
Fix parsing of /** **/ nested block comments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,5 +51,6 @@ Toliver <teejae@gmail.com>
 Toni Müller <toni.mueller@datameer.com>
 Tyler Jones <tyler.jones@txwormhole.com>
 Uku Pattak <ukupat@gmail.com>
+Wylie Conlon <wylie@superblockshq.com>
 Xin Hu <hoosin.git@gmail.com>
 Zhongxian Liang <zhongxian.liang@shopee.com>

--- a/src/lexer/NestedComment.ts
+++ b/src/lexer/NestedComment.ts
@@ -2,7 +2,7 @@
 import { RegExpLike } from './TokenizerEngine.js';
 
 const START = /\/\*/uy; // matches: /*
-const MIDDLE = /([^/*]|\*[^/]|\/[^*])+/uy; // matches text NOT containing /* or */
+const ANY_CHAR = /[\s\S]/uy; // matches single character
 const END = /\*\//uy; // matches: */
 
 /**
@@ -31,7 +31,7 @@ export class NestedComment implements RegExpLike {
       } else if ((match = this.matchSection(END, input))) {
         result += match;
         nestLevel--;
-      } else if ((match = this.matchSection(MIDDLE, input))) {
+      } else if ((match = this.matchSection(ANY_CHAR, input))) {
         result += match;
       } else {
         return null;

--- a/test/features/comments.ts
+++ b/test/features/comments.ts
@@ -239,6 +239,12 @@ export default function supportsComments(format: FormatFn, opts: CommentsConfig 
     `);
   });
 
+  // Regression test for #747
+  it('handles block comments with /** and **/ patterns', () => {
+    const sql = `/** This is a block comment **/`;
+    expect(format(sql)).toBe(sql);
+  });
+
   if (opts.hashComments) {
     it('supports # line comment', () => {
       const result = format('SELECT alpha # commment\nFROM beta');


### PR DESCRIPTION
Don't try to be too clever with matching lots of characters with that funky MIDDLE regex. Just match a single char.

Fixes #747