### PR TITLE
added support for decimal values without leading digits

### DIFF
--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -51,7 +51,7 @@ export default class Tokenizer {
       {
         type: TokenType.NUMBER,
         regex:
-          /(?:0x[0-9a-fA-F]+|0b[01]+|(?:-\s*)?[0-9]+(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+(?:\.[0-9]+)?)?)(?![\w\p{Alphabetic}])/uy,
+          /(?:0x[0-9a-fA-F]+|0b[01]+|(?:-\s*)?(?:[0-9]*\.[0-9]+|[0-9]+(?:\.[0-9]*)?)(?:[eE][-+]?[0-9]+(?:\.[0-9]+)?)?)(?![\w\p{Alphabetic}])/uy,
       },
       // RESERVED_PHRASE is matched before all other keyword tokens
       // to e.g. prioritize matching "TIMESTAMP WITH TIME ZONE" phrase over "WITH" clause.

--- a/test/behavesLikeSqlFormatter.ts
+++ b/test/behavesLikeSqlFormatter.ts
@@ -279,4 +279,19 @@ export default function behavesLikeSqlFormatter(format: FormatFn) {
         tbl;
     `);
   });
+
+  it('supports decimal values without leading digits', () => {
+    const result = format(`
+	  SELECT employee_id FROM employees WHERE salary > .456 * 1000000 AND bonus < .0000239 * salary;
+	`);
+    expect(result).toBe(dedent`
+      SELECT
+        employee_id
+      FROM
+        employees
+      WHERE
+        salary > .456 * 1000000
+        AND bonus < .0000239 * salary;
+    `);
+  });
 }


### PR DESCRIPTION
Encountered issue while handling decimal values without leading digits (for example .00457). Lexer was breaking, updated number token regex to support the similar cases and added a corresponding test case.

Sample SQL query:  `SELECT employee_id FROM employees WHERE salary > .456 * 1000000 AND bonus < .0000239 * salary;`
```
An Unexpected Error Occurred
Parse error at token: 456 at line 1 column 51 Unexpected NUMBER token: {"type":"NUMBER","raw":"456","text":"456","start":50}
```