### PR TITLE
Add more PostgreSQL keywords and phrases

### DIFF
--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -172,7 +172,7 @@ const tabularOnelineClauses = expandPhrases([
   'DROP IDENTITY',
   'DROP INDEX',
   'DROP LANGUAGE',
-  'DROP MATERIALIZED VIEW',
+  'DROP MATERIALIZED VIEW [IF EXISTS]',
   'DROP OPERATOR',
   'DROP OPERATOR CLASS',
   'DROP OPERATOR FAMILY',
@@ -216,7 +216,7 @@ const tabularOnelineClauses = expandPhrases([
   'REFRESH MATERIALIZED VIEW',
   'REINDEX',
   'RELEASE SAVEPOINT',
-  'RESET',
+  'RESET [ALL|ROLE|SESSION AUTHORIZATION]',
   'REVOKE',
   'ROLLBACK',
   'ROLLBACK PREPARED',
@@ -252,11 +252,15 @@ const reservedPhrases = expandPhrases([
   'PRIMARY KEY',
   'GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY',
   'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
+  'DO {NOTHING | UPDATE}',
+  'AS MATERIALIZED',
   '{ROWS | RANGE | GROUPS} BETWEEN',
   // https://www.postgresql.org/docs/current/datatype-datetime.html
   '[TIMESTAMP | TIME] {WITH | WITHOUT} TIME ZONE',
   // comparison operator
   'IS [NOT] DISTINCT FROM',
+  'NULLS {FIRST | LAST}',
+  'WITH ORDINALITY',
 ]);
 
 // https://www.postgresql.org/docs/14/index.html

--- a/src/languages/postgresql/postgresql.keywords.ts
+++ b/src/languages/postgresql/postgresql.keywords.ts
@@ -98,7 +98,6 @@ export const keywords: string[] = [
   'SYMMETRIC', // reserved
   'TABLE', // reserved
   'TABLESAMPLE', // reserved (can be function or type)
-  'TEMPLATE', // non-reserved, used in CREATE DATABASE to specify a template database
   'THEN', // reserved
   'TO', // reserved, requires AS
   'TRAILING', // reserved

--- a/src/languages/postgresql/postgresql.keywords.ts
+++ b/src/languages/postgresql/postgresql.keywords.ts
@@ -98,6 +98,7 @@ export const keywords: string[] = [
   'SYMMETRIC', // reserved
   'TABLE', // reserved
   'TABLESAMPLE', // reserved (can be function or type)
+  'TEMPLATE', // non-reserved, used in CREATE DATABASE to specify a template database
   'THEN', // reserved
   'TO', // reserved, requires AS
   'TRAILING', // reserved


### PR DESCRIPTION
Closes #809

```diff
- user_job_posting AS materialized (
+ user_job_posting AS MATERIALIZED (
```
>
```diff
- ON CONFLICT DO nothing
+ ON CONFLICT DO NOTHING
```
  
```diff
- ON CONFLICT (foreign_cloudinary_asset_id) DO nothing
+ ON CONFLICT (foreign_cloudinary_asset_id) DO NOTHING
```
  
```diff
- WITH ordinality nids
+ WITH ORDINALITY nids
```
  
```diff
- ORDER BY job_posting_approved_at DESC nulls last,
+ ORDER BY job_posting_approved_at DESC NULLS LAST,
```
  
```diff
+ DROP MATERIALIZED VIEW if EXISTS discover_independents_user_account_v3 CASCADE;
+ DROP MATERIALIZED VIEW IF EXISTS discover_independents_user_account_v3 CASCADE;
```
  
```diff
- RESET role;
+ RESET ROLE;
```

Some specific examples:

```sql
-- Before
SELECT
  fruit,
  pos 
FROM
  unnest(
    ARRAY['apple', 'banana', 'cherry']
  )
WITH
  ordinality AS fruits (fruit, pos);

-- After
SELECT
  fruit,
  pos 
FROM
  unnest(
    ARRAY['apple', 'banana', 'cherry']
  )
WITH ORDINALITY AS fruits (fruit, pos);
```