### PR TITLE
Add support for Postgresql JSON and JSONB data types

### DIFF
--- a/src/languages/postgresql/postgresql.keywords.ts
+++ b/src/languages/postgresql/postgresql.keywords.ts
@@ -139,6 +139,8 @@ export const dataTypes: string[] = [
   'INTERVAL', // (cannot be function or type)
   'NCHAR', // (cannot be function or type)
   'NUMERIC', // (cannot be function or type)
+  'JSON',
+  'JSONB',
   'PRECISION', // (cannot be function or type), requires AS
   'REAL', // (cannot be function or type)
   'SMALLINT', // (cannot be function or type)

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -390,4 +390,12 @@ describe('PostgreSqlFormatter', () => {
       CREATE OR REPLACE FUNCTION foo ();
     `);
   });
+
+  it('formats JSON and JSONB data types', () => {
+    expect(
+      format(`CREATE TABLE foo (bar json, baz jsonb);`, {
+        dataTypeCase: 'upper',
+      })
+    ).toBe('CREATE TABLE foo (bar JSON, baz JSONB);');
+  });
 });


### PR DESCRIPTION
Hey there,

I noticed some data types in where missing in [`postgres.keywords.ts`.](https://github.com/sql-formatter-org/sql-formatter/blob/93a423bcb552d5158cac153208485256f57e9f71/src/languages/postgresql/postgresql.keywords.ts#L121) There is a comment in that file linking to the official documentation: https://www.postgresql.org/docs/current/datatype.html. 

We are using the `JSONB` data type in our project so I thought I would add support for `JSON` + `JSONB` in this pull request. There might be more types needed to be added, but for now I thought I'd add these that I knew where missing.

Please let me know if there is anything else I should do to get this pull request merged.