### PR TITLE
chore: replace get-stdin with native stream/consumers

### DIFF
--- a/bin/sql-formatter-cli.cjs
+++ b/bin/sql-formatter-cli.cjs
@@ -9,7 +9,7 @@ const tty = require('tty');
 const { version } = require('../package.json');
 const { ArgumentParser } = require('argparse');
 const { promisify } = require('util');
-const getStdin = require('get-stdin');
+const { text } = require('node:stream/consumers');
 
 class SqlFormatterCli {
   constructor() {
@@ -117,7 +117,7 @@ class SqlFormatterCli {
     if (this.args.file) {
       return await this.readFile(infile);
     } else {
-      return await getStdin();
+      return await text(process.stdin);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   },
   "dependencies": {
     "argparse": "^2.0.1",
-    "get-stdin": "=8.0.0",
     "nearley": "^2.20.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,11 +3541,6 @@ get-package-type@^0.1.0:
   resolved "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-stdin@=8.0.0:
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz"
-  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
-
 get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"


### PR DESCRIPTION
This follows the recommendation from [Sindre Sorhus (author of get-stdin)](https://github.com/sindresorhus/get-stdin/tree/main?tab=readme-ov-file#tip) to use the built-in streamConsumers.text() in modern Node.js versions. Reduces external dependencies while maintaining identical functionality.