### PR TITLE
Recognize referential actions as keywords in ON UPDATE/DELETE

### DIFF
--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -251,7 +251,7 @@ const reservedJoins = expandPhrases([
 const reservedPhrases = expandPhrases([
   'PRIMARY KEY',
   'GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY',
-  'ON {UPDATE | DELETE} [CASCADE | SET NULL | SET DEFAULT]',
+  'ON {UPDATE | DELETE} [NO ACTION | RESTRICT | CASCADE | SET NULL | SET DEFAULT]',
   'DO {NOTHING | UPDATE}',
   'AS MATERIALIZED',
   '{ROWS | RANGE | GROUPS} BETWEEN',

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -251,7 +251,7 @@ const reservedJoins = expandPhrases([
 const reservedPhrases = expandPhrases([
   'PRIMARY KEY',
   'GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY',
-  'ON {UPDATE | DELETE} [SET NULL | SET DEFAULT]',
+  'ON {UPDATE | DELETE} [CASCADE | SET NULL | SET DEFAULT]',
   'DO {NOTHING | UPDATE}',
   'AS MATERIALIZED',
   '{ROWS | RANGE | GROUPS} BETWEEN',


### PR DESCRIPTION
Hi @nene, hope you're good! 👋

Currently, `sql-formatter@15.5.1` does not recognize [the PostgreSQL `CASCADE`, `NO ACTION` or `RESTRICT` referential actions](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-REFERENCES) as keywords.

This means that if identifiers are configured to be lowercased, the referential actions will be lower cased, eg. `ON DELETE cascade`:

```sql
CREATE TABLE orders (
  id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
  customer_id integer REFERENCES customers (id) ON DELETE cascade
);
```

![Screenshot 2025-03-24 at 16 31 07](https://github.com/user-attachments/assets/81aab140-1cb2-4769-9a8e-c66d3909bada)

This PR adjusts the `reservedPhrases` for PostgreSQL to add the `CASCADE`, `NO ACTION` and `RESTRICT` keywords as suffixes for `ON UPDATE` and `ON DELETE`.