### PR TITLE
Add DuckDB to webpage dropdown

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -61,6 +61,7 @@
               <option value="bigquery">BigQuery</option>
               <option value="db2">DB2</option>
               <option value="db2i">DB2 for IBM i</option>
+              <option value="duckdb">DuckDB</option>
               <option value="hive">Hive</option>
               <option value="mariadb">MariaDB</option>
               <option value="mysql">MySQL</option>


### PR DESCRIPTION
DuckDB was missing from the language dropdown.