### PR TITLE
Allow ODBC date format. Closes #877

### DIFF
--- a/src/languages/transactsql/transactsql.formatter.ts
+++ b/src/languages/transactsql/transactsql.formatter.ts
@@ -246,7 +246,10 @@ export const transactsql: DialectOptions = {
     reservedDataTypes: dataTypes,
     reservedFunctionNames: functions,
     nestedBlockComments: true,
-    stringTypes: [{ quote: "''-qq", prefixes: ['N'] }],
+    stringTypes: [
+      { quote: "''-qq", prefixes: ['N'] },
+      '{}'
+    ],
     identTypes: [`""-qq`, '[]'],
     identChars: { first: '#@', rest: '#@$' },
     paramTypes: { named: ['@'], quoted: ['@'] },

--- a/test/transactsql.test.ts
+++ b/test/transactsql.test.ts
@@ -227,4 +227,22 @@ describe('TransactSqlFormatter', () => {
         Zone
     `);
   });
+
+  // Issue #877
+  it('allows the use of the ODBC date format', () => {
+    const result = format(
+      `WITH [sales_query] AS (SELECT [customerId] FROM [segments].dbo.[sales] WHERE [salesdate] > {d'2024-01-01'})`
+    );
+    expect(result).toBe(dedent`
+      WITH
+        [sales_query] AS (
+          SELECT
+            [customerId]
+          FROM
+            [segments].dbo.[sales]
+          WHERE
+            [salesdate] > {d'2024-01-01'}
+        )
+    `);
+  });
 });


### PR DESCRIPTION
Supports the [ODBC date format](https://learn.microsoft.com/en-us/sql/t-sql/data-types/date-transact-sql?view=sql-server-ver17#odbc-date-format) by specifying `{}` as `stringTypes`.