### PR TITLE
Add $schema property to schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -5,6 +5,10 @@
   "additionalProperties": false,
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "The schema to verify this document against."
+    },
     "dataTypeCase": {
       "description": "Converts data types to upper- or lowercase.",
       "$ref": "#/$defs/casing"


### PR DESCRIPTION
This will allow one to link the schema directly in the file, as supported by editors like VSCode and Zed by default.

Example:

```json
{
  "$schema": "https://raw.githubusercontent.com/sql-formatter-org/sql-formatter/refs/heads/master/schema.json",
  "language": "sqlite",
  "tabWidth": 2,
  "keywordCase": "upper",
}
```