### PR TITLE
Add missing PostgreSQL operators and fix >^ geometric operator

### DIFF
--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -319,6 +319,7 @@ export const postgresql: DialectOptions = {
       '##',
       '<->',
       '&&',
+      '&&&',
       '&<',
       '&>',
       '<<|',
@@ -326,7 +327,7 @@ export const postgresql: DialectOptions = {
       '|>>',
       '|&>',
       '<^',
-      '^>',
+      '>^',
       '?#',
       '?-',
       '?|',
@@ -334,7 +335,10 @@ export const postgresql: DialectOptions = {
       '?||',
       '@>',
       '<@',
+      '<@>',
       '~=',
+      // PostGIS
+      '|=|',
       // JSON
       '?',
       '@?',
@@ -376,6 +380,10 @@ export const postgresql: DialectOptions = {
       '<->>',
       '<<<->',
       '<->>>',
+      // Cube
+      '~>',
+      // Hstore
+      '#=',
       // Type cast
       '::',
       ':',

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -66,6 +66,7 @@ describe('PostgreSqlFormatter', () => {
       '##',
       '<->',
       '&&',
+      '&&&',
       '&<',
       '&>',
       '<<|',
@@ -73,7 +74,7 @@ describe('PostgreSqlFormatter', () => {
       '|>>',
       '|&>',
       '<^',
-      '^>',
+      '>^',
       '?#',
       '?-',
       '?|',
@@ -81,7 +82,10 @@ describe('PostgreSqlFormatter', () => {
       '?||',
       '@>',
       '<@',
+      '<@>',
       '~=',
+      // PostGIS
+      '|=|',
       // JSON
       '?',
       '@?',
@@ -123,6 +127,10 @@ describe('PostgreSqlFormatter', () => {
       '<->>',
       '<<<->',
       '<->>>',
+      // Cube
+      '~>',
+      // Hstore
+      '#=',
       // Custom operators: from pgvector extension
       '<#>',
       '<=>',
@@ -249,5 +257,129 @@ describe('PostgreSqlFormatter', () => {
     expect(format(`comment on table foo is 'Hello my table';`, { keywordCase: 'upper' })).toBe(
       dedent`COMMENT ON TABLE foo IS 'Hello my table';`
     );
+  });
+
+  // Tests for PostgreSQL containment and full-text search operators
+  describe('containment and search operators', () => {
+    it('formats @> (contains) operator in WHERE clause', () => {
+      expect(format(`SELECT * FROM foo WHERE bar @> '{1,2}';`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        WHERE
+          bar @> '{1,2}';
+      `);
+    });
+
+    it('formats <@ (contained by) operator in WHERE clause', () => {
+      expect(format(`SELECT * FROM foo WHERE bar <@ '{1,2,3}';`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        WHERE
+          bar <@ '{1,2,3}';
+      `);
+    });
+
+    // https://www.postgresql.org/docs/current/earthdistance.html
+    it('formats <@> (distance) operator in ORDER BY clause', () => {
+      expect(format(`SELECT * FROM foo ORDER BY bar <@> point(1,2);`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        ORDER BY
+          bar <@> point(1, 2);
+      `);
+    });
+
+    it('formats @> operator with JSONB data', () => {
+      expect(format(`SELECT * FROM foo WHERE data @> '{"key": "value"}';`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        WHERE
+          data @> '{"key": "value"}';
+      `);
+    });
+
+    it('formats <@ operator with JSONB data', () => {
+      expect(format(`SELECT * FROM foo WHERE data <@ '{"key": "value", "other": 1}';`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        WHERE
+          data <@ '{"key": "value", "other": 1}';
+      `);
+    });
+  });
+
+  // Tests for PostGIS operators
+  describe('PostGIS operators', () => {
+    // https://postgis.net/docs/geometry_overlaps_nd.html
+    it('formats &&& (3D bounding box overlap) operator', () => {
+      expect(format(`SELECT * FROM foo WHERE geom_a &&& geom_b;`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        WHERE
+          geom_a &&& geom_b;
+      `);
+    });
+
+    // https://postgis.net/docs/geometry_distance_cpa.html
+    it('formats |=| (closest point of approach distance) operator', () => {
+      expect(format(`SELECT * FROM foo ORDER BY traj_a |=| traj_b;`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        ORDER BY
+          traj_a |=| traj_b;
+      `);
+    });
+  });
+
+  // https://www.postgresql.org/docs/current/functions-geometry.html
+  // Note: the formatter defines ^> but PostgreSQL docs say the operator is >^
+  describe('geometric operator correctness', () => {
+    it('formats >^ (is above) operator', () => {
+      expect(format(`SELECT * FROM foo WHERE point(1,2) >^ point(3,4);`)).toBe(dedent`
+        SELECT
+          *
+        FROM
+          foo
+        WHERE
+          point(1, 2) >^ point(3, 4);
+      `);
+    });
+  });
+
+  // Tests for extension operators (hstore, cube, ltree)
+  describe('extension operators', () => {
+    // https://www.postgresql.org/docs/current/cube.html
+    it('formats ~> (cube coordinate extraction) operator', () => {
+      expect(format(`SELECT c ~> 1 FROM foo;`)).toBe(dedent`
+        SELECT
+          c ~> 1
+        FROM
+          foo;
+      `);
+    });
+
+    // https://www.postgresql.org/docs/current/hstore.html
+    it('formats #= (hstore replace fields) operator', () => {
+      expect(format(`SELECT row #= hstore_data FROM foo;`)).toBe(dedent`
+        SELECT
+          row #= hstore_data
+        FROM
+          foo;
+      `);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds support for 5 PostgreSQL operators from core and popular extensions that were incorrectly tokenized (split into shorter operators): `<@>` (earthdistance), `&&&` (PostGIS 3D overlap), `|=|` (PostGIS trajectory distance), `~>` (cube), `#=` (hstore)
- Fixes the geometric "is above" operator which was defined as `^>` instead of `>^` per [PostgreSQL docs](https://www.postgresql.org/docs/current/functions-geometry.html)
- Adds unit tests for each operator in realistic SQL contexts, with links to relevant PostgreSQL/PostGIS documentation

## Detail

The formatter's tokenizer was greedily matching shorter known operators instead of the full operator. For example `<@>` was being split into `<@` + `>`, producing `bar <@ > point(1, 2)` instead of `bar <@> point(1, 2)`.

The fix is simply adding these operators to the PostgreSQL dialect's operator list. The existing regex builder in `regexFactory.ts` already sorts operators by length descending, so longer operators automatically take priority.

### Operators added

| Operator | Source | Docs |
|----------|--------|------|
| `<@>` | earthdistance extension | [earthdistance](https://www.postgresql.org/docs/current/earthdistance.html) |
| `&&&` | PostGIS | [geometry_overlaps_nd](https://postgis.net/docs/geometry_overlaps_nd.html) |
| `\|=\|` | PostGIS | [geometry_distance_cpa](https://postgis.net/docs/geometry_distance_cpa.html) |
| `~>` | cube extension | [cube](https://www.postgresql.org/docs/current/cube.html) |
| `#=` | hstore extension | [hstore](https://www.postgresql.org/docs/current/hstore.html) |
| `>^` (fix) | geometric | [functions-geometry](https://www.postgresql.org/docs/current/functions-geometry.html) |

## Test plan
- [x] All new operators tested via `supportsOperators()` for basic spacing and dense mode
- [x] All new operators tested in realistic SQL contexts (WHERE, ORDER BY, SELECT)
- [x] Full PostgreSQL test suite passes (460 tests)