### PR TITLE
Add support for PostgreSQL keywords in CREATE CONSTRAINT TRIGGER

### DIFF
--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -63,7 +63,9 @@ const tabularOnelineClauses = expandPhrases([
   // other
   'SET SCHEMA',
   '{BEFORE | AFTER | INSTEAD OF} {INSERT | UPDATE [OF] | DELETE | TRUNCATE}',
-  'DEFERRABLE INITIALLY DEFERRED',
+  '[NOT] DEFERRABLE',
+  'INITIALLY {DEFERRED | IMMEDIATE}',
+  '[NOT] DEFERRABLE INITIALLY {DEFERRED | IMMEDIATE}',
   // https://www.postgresql.org/docs/14/sql-commands.html
   'ABORT',
   'ALTER AGGREGATE',

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -40,6 +40,7 @@ const tabularOnelineClauses = expandPhrases([
   'CREATE [MATERIALIZED] VIEW [IF NOT EXISTS]',
   // - update:
   'UPDATE [ONLY]',
+  'UPDATE OF',
   'WHERE CURRENT OF',
   // - insert:
   'ON CONFLICT',
@@ -62,7 +63,8 @@ const tabularOnelineClauses = expandPhrases([
   'TRUNCATE [TABLE] [ONLY]',
   // other
   'SET SCHEMA',
-  'AFTER',
+  'AFTER [INSERT]',
+  'DEFERRABLE INITIALLY DEFERRED',
   // https://www.postgresql.org/docs/14/sql-commands.html
   'ABORT',
   'ALTER AGGREGATE',
@@ -200,7 +202,7 @@ const tabularOnelineClauses = expandPhrases([
   'DROP USER',
   'DROP USER MAPPING',
   'DROP VIEW',
-  'EXECUTE',
+  'EXECUTE [FUNCTION | PROCEDURE]',
   'EXPLAIN',
   'FETCH',
   'GRANT',
@@ -255,6 +257,7 @@ const reservedKeywordPhrases = expandPhrases([
   'ON {UPDATE | DELETE} [NO ACTION | RESTRICT | CASCADE | SET NULL | SET DEFAULT]',
   'DO {NOTHING | UPDATE}',
   'AS MATERIALIZED',
+  'FOR EACH ROW',
   '{ROWS | RANGE | GROUPS} BETWEEN',
   // comparison operator
   'IS [NOT] DISTINCT FROM',

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -40,7 +40,6 @@ const tabularOnelineClauses = expandPhrases([
   'CREATE [MATERIALIZED] VIEW [IF NOT EXISTS]',
   // - update:
   'UPDATE [ONLY]',
-  'UPDATE OF',
   'WHERE CURRENT OF',
   // - insert:
   'ON CONFLICT',
@@ -63,7 +62,7 @@ const tabularOnelineClauses = expandPhrases([
   'TRUNCATE [TABLE] [ONLY]',
   // other
   'SET SCHEMA',
-  'AFTER [INSERT]',
+  '{BEFORE | AFTER | INSTEAD OF} {INSERT | UPDATE [OF] | DELETE | TRUNCATE}',
   'DEFERRABLE INITIALLY DEFERRED',
   // https://www.postgresql.org/docs/14/sql-commands.html
   'ABORT',
@@ -258,6 +257,7 @@ const reservedKeywordPhrases = expandPhrases([
   'DO {NOTHING | UPDATE}',
   'AS MATERIALIZED',
   'FOR EACH ROW',
+  'OR {INSERT | UPDATE [OF] | DELETE | TRUNCATE}',
   '{ROWS | RANGE | GROUPS} BETWEEN',
   // comparison operator
   'IS [NOT] DISTINCT FROM',

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -1,25 +1,23 @@
 import dedent from 'dedent-js';
-
 import { format as originalFormat, FormatFn } from '../src/sqlFormatter.js';
-
+import behavesLikePostgresqlFormatter from './behavesLikePostgresqlFormatter.js';
+import supportsArrayLiterals from './features/arrayLiterals.js';
+import supportsConstraints from './features/constraints.js';
 import supportsCreateTable from './features/createTable.js';
+import supportsCreateView from './features/createView.js';
 import supportsDropTable from './features/dropTable.js';
+import supportsIdentifiers from './features/identifiers.js';
+import supportsIsDistinctFrom from './features/isDistinctFrom.js';
 import supportsJoin from './features/join.js';
+import supportsLimiting from './features/limiting.js';
 import supportsOperators from './features/operators.js';
 import supportsSchema from './features/schema.js';
-import supportsStrings from './features/strings.js';
-import supportsConstraints from './features/constraints.js';
-import supportsIdentifiers from './features/identifiers.js';
-import supportsParams from './options/param.js';
 import supportsSetOperations from './features/setOperations.js';
-import supportsLimiting from './features/limiting.js';
-import supportsUpdate from './features/update.js';
+import supportsStrings from './features/strings.js';
 import supportsTruncateTable from './features/truncateTable.js';
-import supportsCreateView from './features/createView.js';
-import supportsIsDistinctFrom from './features/isDistinctFrom.js';
-import supportsArrayLiterals from './features/arrayLiterals.js';
+import supportsUpdate from './features/update.js';
 import supportsDataTypeCase from './options/dataTypeCase.js';
-import behavesLikePostgresqlFormatter from './behavesLikePostgresqlFormatter.js';
+import supportsParams from './options/param.js';
 
 describe('PostgreSqlFormatter', () => {
   const language = 'postgresql';
@@ -257,5 +255,28 @@ describe('PostgreSqlFormatter', () => {
     expect(format(`comment on table foo is 'Hello my table';`, { keywordCase: 'upper' })).toBe(
       dedent`COMMENT ON TABLE foo IS 'Hello my table';`
     );
+  });
+
+  it('formats keywords in CREATE CONSTRAINT TRIGGER', () => {
+    expect(
+      format(
+        `CREATE CONSTRAINT TRIGGER example_trigger
+        AFTER INSERT
+        OR
+        UPDATE OF column_a,
+        column_b ON example_table
+        DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
+        EXECUTE PROCEDURE example_function ();`,
+        { keywordCase: 'upper' }
+      )
+    ).toBe(dedent`
+      CREATE CONSTRAINT TRIGGER example_trigger
+      AFTER INSERT
+      OR
+      UPDATE OF column_a,
+      column_b ON example_table
+      DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
+      EXECUTE PROCEDURE example_function ();
+    `);
   });
 });

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -1,23 +1,25 @@
 import dedent from 'dedent-js';
+
 import { format as originalFormat, FormatFn } from '../src/sqlFormatter.js';
-import behavesLikePostgresqlFormatter from './behavesLikePostgresqlFormatter.js';
-import supportsArrayLiterals from './features/arrayLiterals.js';
-import supportsConstraints from './features/constraints.js';
+
 import supportsCreateTable from './features/createTable.js';
-import supportsCreateView from './features/createView.js';
 import supportsDropTable from './features/dropTable.js';
-import supportsIdentifiers from './features/identifiers.js';
-import supportsIsDistinctFrom from './features/isDistinctFrom.js';
 import supportsJoin from './features/join.js';
-import supportsLimiting from './features/limiting.js';
 import supportsOperators from './features/operators.js';
 import supportsSchema from './features/schema.js';
-import supportsSetOperations from './features/setOperations.js';
 import supportsStrings from './features/strings.js';
-import supportsTruncateTable from './features/truncateTable.js';
-import supportsUpdate from './features/update.js';
-import supportsDataTypeCase from './options/dataTypeCase.js';
+import supportsConstraints from './features/constraints.js';
+import supportsIdentifiers from './features/identifiers.js';
 import supportsParams from './options/param.js';
+import supportsSetOperations from './features/setOperations.js';
+import supportsLimiting from './features/limiting.js';
+import supportsUpdate from './features/update.js';
+import supportsTruncateTable from './features/truncateTable.js';
+import supportsCreateView from './features/createView.js';
+import supportsIsDistinctFrom from './features/isDistinctFrom.js';
+import supportsArrayLiterals from './features/arrayLiterals.js';
+import supportsDataTypeCase from './options/dataTypeCase.js';
+import behavesLikePostgresqlFormatter from './behavesLikePostgresqlFormatter.js';
 
 describe('PostgreSqlFormatter', () => {
   const language = 'postgresql';

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -260,14 +260,14 @@ describe('PostgreSqlFormatter', () => {
   it('formats keywords in CREATE CONSTRAINT TRIGGER', () => {
     expect(
       format(
-        `CREATE CONSTRAINT TRIGGER example_trigger
-        AFTER INSERT
-        OR
-        UPDATE OF column_a,
-        column_b ON example_table
-        DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
-        EXECUTE PROCEDURE example_function ();`,
-        { keywordCase: 'upper' }
+        `create constraint trigger Example_Trigger
+        after insert
+        or
+        update of Column_A,
+        Column_B on Example_Table
+        deferrable initially deferred for each row
+        execute procedure Example_Function ();`,
+        { keywordCase: 'upper', identifierCase: 'lower' }
       )
     ).toBe(dedent`
       CREATE CONSTRAINT TRIGGER example_trigger

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -273,12 +273,26 @@ describe('PostgreSqlFormatter', () => {
       )
     ).toBe(dedent`
       CREATE CONSTRAINT TRIGGER example_trigger
-      AFTER INSERT
-      OR
-      UPDATE OF column_a,
+      AFTER INSERT OR UPDATE OF column_a,
       column_b ON example_table
       DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
       EXECUTE PROCEDURE example_function ();
+    `);
+  });
+
+  it('formats multiple CREATE TRIGGER events without treating OR as a logical operator', () => {
+    expect(
+      format(
+        `create trigger Example_Trigger
+        after insert or update or delete on Example_Table
+        for each row
+        execute function Example_Function ();`,
+        { keywordCase: 'upper', identifierCase: 'lower' }
+      )
+    ).toBe(dedent`
+      CREATE TRIGGER example_trigger
+      AFTER INSERT OR UPDATE OR DELETE ON example_table FOR EACH ROW
+      EXECUTE FUNCTION example_function ();
     `);
   });
 });


### PR DESCRIPTION
Config:

```js
language: 'postgresql',
keywordCase: 'upper',
identifierCase: 'lower',
```

Before:

```sql
CREATE CONSTRAINT TRIGGER example_trigger
AFTER insert
OR
UPDATE of column_a,
column_b ON example_table DEFERRABLE INITIALLY deferred FOR each ROW
EXECUTE procedure example_function ();

CREATE TRIGGER example_trigger
AFTER insert
OR
UPDATE
OR delete ON example_table FOR each ROW
EXECUTE function example_function ();
```

After:

```sql
CREATE CONSTRAINT TRIGGER example_trigger
AFTER INSERT OR UPDATE OF column_a,
column_b ON example_table
DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
EXECUTE PROCEDURE example_function ();

CREATE TRIGGER example_trigger
AFTER INSERT OR UPDATE OR DELETE ON example_table FOR EACH ROW
EXECUTE FUNCTION example_function ();
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL formatting now recognizes additional reserved multi-word phrases and variants (improves handling of trigger/constraint event clauses, EXECUTE forms, AFTER/DEFERRABLE variants, and FOR EACH ROW) for more accurate SQL output.

* **Tests**
  * Added regression tests verifying CREATE CONSTRAINT/TRIGGER formatting and correct casing preservation for keywords and identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sql-formatter-org/sql-formatter/pull/948)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->