### PR TITLE
fix: keep spaces around - operator in dialects with dashed identifiers

### DIFF
--- a/src/dialect.ts
+++ b/src/dialect.ts
@@ -34,15 +34,17 @@ export const createDialect = (options: DialectOptions): Dialect => {
 
 const dialectFromOptions = (dialectOptions: DialectOptions): Dialect => ({
   tokenizer: new Tokenizer(dialectOptions.tokenizerOptions, dialectOptions.name),
-  formatOptions: processDialectFormatOptions(dialectOptions.formatOptions),
+  formatOptions: processDialectFormatOptions(dialectOptions),
 });
 
-const processDialectFormatOptions = (
-  options: DialectFormatOptions
-): ProcessedDialectFormatOptions => ({
+const processDialectFormatOptions = ({
+  tokenizerOptions,
+  formatOptions: options,
+}: DialectOptions): ProcessedDialectFormatOptions => ({
   alwaysDenseOperators: options.alwaysDenseOperators || [],
   onelineClauses: Object.fromEntries(options.onelineClauses.map(name => [name, true])),
   tabularOnelineClauses: Object.fromEntries(
     (options.tabularOnelineClauses ?? options.onelineClauses).map(name => [name, true])
   ),
+  identifierDashes: Boolean(tokenizerOptions.identChars?.dashes),
 });

--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -60,6 +60,10 @@ export interface ProcessedDialectFormatOptions {
   alwaysDenseOperators: string[];
   onelineClauses: Record<string, boolean>;
   tabularOnelineClauses: Record<string, boolean>;
+  // True when the dialect allows dashes inside identifiers (e.g. BigQuery).
+  // In such dialects the "-" operator must keep its surrounding spaces,
+  // otherwise "a - b" densed to "a-b" would re-parse as a single identifier.
+  identifierDashes: boolean;
 }
 
 /** Formats a generic SQL expression */
@@ -330,7 +334,12 @@ export default class ExpressionFormatter {
   }
 
   private formatOperator({ text }: OperatorNode) {
-    if (this.cfg.denseOperators || this.dialectCfg.alwaysDenseOperators.includes(text)) {
+    // In dialects that allow dashes inside identifiers (e.g. BigQuery) the "-"
+    // operator must keep its surrounding spaces. Densing "a - b" into "a-b"
+    // would otherwise re-parse as a single dashed identifier.
+    if (text === '-' && this.dialectCfg.identifierDashes) {
+      this.layout.add(text, WS.SPACE);
+    } else if (this.cfg.denseOperators || this.dialectCfg.alwaysDenseOperators.includes(text)) {
       this.layout.add(WS.NO_SPACE, text);
     } else if (text === ':') {
       this.layout.add(WS.NO_SPACE, text, WS.SPACE);

--- a/test/bigquery.test.ts
+++ b/test/bigquery.test.ts
@@ -58,7 +58,10 @@ describe('BigQueryFormatter', () => {
     'EXCEPT DISTINCT',
     'INTERSECT DISTINCT',
   ]);
-  supportsOperators(format, ['&', '|', '^', '~', '>>', '<<', '||', '=>'], { any: true });
+  supportsOperators(format, ['&', '|', '^', '~', '>>', '<<', '||', '=>'], {
+    any: true,
+    identifierDashes: true,
+  });
   supportsIsDistinctFrom(format);
   supportsParams(format, { positional: true, named: ['@'], quoted: ['@``'] });
   supportsWindow(format);
@@ -77,6 +80,19 @@ describe('BigQueryFormatter', () => {
         where-long-identifier
       FROM
         beta
+    `);
+  });
+
+  // Because dashes are allowed inside identifiers, densing the "-" operator
+  // would glue its operands into a single identifier ("a - b" -> "a-b"),
+  // changing the meaning of the query. So denseOperators must keep it spaced.
+  it('keeps spaces around the - operator in dense mode', () => {
+    expect(format('SELECT a - b, x - foo(y)\nFROM t', { denseOperators: true })).toBe(dedent`
+      SELECT
+        a - b,
+        x - foo (y)
+      FROM
+        t
     `);
   });
 

--- a/test/features/operators.ts
+++ b/test/features/operators.ts
@@ -5,6 +5,9 @@ import { FormatFn } from '../../src/sqlFormatter.js';
 type OperatorsConfig = {
   logicalOperators?: string[];
   any?: boolean;
+  // True for dialects that allow dashes inside identifiers (e.g. BigQuery),
+  // where the "-" operator must keep its surrounding spaces even in dense mode.
+  identifierDashes?: boolean;
 };
 
 export default function supportsOperators(
@@ -27,7 +30,13 @@ export default function supportsOperators(
 
   operators.forEach(op => {
     it(`supports ${op} operator in dense mode`, () => {
-      expect(format(`foo ${op} bar`, { denseOperators: true })).toBe(`foo${op}bar`);
+      // In dialects with dashed identifiers, "foo-bar" would re-parse as a
+      // single identifier, so the "-" operator keeps its surrounding spaces.
+      if (op === '-' && cfg.identifierDashes) {
+        expect(format(`foo ${op} bar`, { denseOperators: true })).toBe(`foo ${op} bar`);
+      } else {
+        expect(format(`foo ${op} bar`, { denseOperators: true })).toBe(`foo${op}bar`);
+      }
     });
   });
 


### PR DESCRIPTION
With `denseOperators: true` on BigQuery, a subtraction like `a - b` comes out as `a-b`. That's not just ugly: BigQuery allows dashes inside identifiers, so the densed output re-parses as a single identifier `a-b`, and `format(format(sql))` no longer matches `format(sql)`. `a - foo(y)` is worse — it becomes `a-foo (y)`, turning the expression into an identifier followed by a call.

The fix is to leave the `-` operator spaced in dialects that allow dashed identifiers (currently just BigQuery). I derived that flag from the existing `identChars.dashes` tokenizer option so there's a single source of truth. Numeric cases like `1 - 2` were already safe (the `-` is parsed into the literal), so this only affects the identifier case.

The shared dense-operator test in `operators.ts` was actually asserting the broken `foo-bar` output for BigQuery; I scoped that to the dashed-identifier dialects and added a BigQuery regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed formatting of the `-` operator in dialects that support dashes in identifiers, such as BigQuery. When dense operator formatting is enabled, spaces around the `-` operator are now properly preserved to prevent expressions from being incorrectly merged into dashed identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->