### PR TITLE
fix: keep a space when densing "-" before a negative operand

### DIFF
--- a/src/formatter/Layout.ts
+++ b/src/formatter/Layout.ts
@@ -57,9 +57,20 @@ export default class Layout {
           this.items.push(WS.SINGLE_INDENT);
           break;
         default:
+          // Don't glue a token starting with "-" directly onto one ending with
+          // "-": that forms "--", which re-parses as a line comment and
+          // swallows the rest of the line (e.g. densing "a - -b" into "a--b").
+          if (typeof item === 'string' && item.startsWith('-') && this.lastTokenEndsWith('-')) {
+            this.items.push(WS.SPACE);
+          }
           this.items.push(item);
       }
     }
+  }
+
+  private lastTokenEndsWith(suffix: string): boolean {
+    const lastItem = last(this.items);
+    return typeof lastItem === 'string' && lastItem.endsWith(suffix);
   }
 
   private trimHorizontalWhitespace() {

--- a/test/features/operators.ts
+++ b/test/features/operators.ts
@@ -40,6 +40,17 @@ export default function supportsOperators(
     });
   });
 
+  it('does not glue a - in front of a negative operand into a line comment in dense mode', () => {
+    // "a - -b" / "1 - -1" must not be densed into "a--b" / "1--1": the "--"
+    // would re-parse as a line comment and silently swallow the rest of the line.
+    ['SELECT a - -b', 'SELECT 1 - -1'].forEach(sql => {
+      const result = format(sql, { denseOperators: true });
+      expect(result).not.toContain('--');
+      // ...and formatting stays idempotent.
+      expect(format(result, { denseOperators: true })).toBe(result);
+    });
+  });
+
   (cfg.logicalOperators || ['AND', 'OR']).forEach(op => {
     it(`supports ${op} operator`, () => {
       const result = format(`SELECT true ${op} false AS foo;`);

--- a/test/sqlFormatter.test.ts
+++ b/test/sqlFormatter.test.ts
@@ -83,6 +83,19 @@ describe('sqlFormatter', () => {
     }).toThrow('commaPosition config is no more supported.');
   });
 
+  it('keeps the boundary space before a negative operand but stays dense elsewhere', () => {
+    // The "--" that "a - -b" would dense into re-parses as a line comment, so that
+    // one boundary keeps its space; everything else still denses ("a-" / "1-").
+    expect(format('SELECT a - -b', { denseOperators: true })).toBe(dedent`
+      SELECT
+        a- -b
+    `);
+    expect(format('SELECT 1 - -1', { denseOperators: true })).toBe(dedent`
+      SELECT
+        1- -1
+    `);
+  });
+
   describe('formatDialect()', () => {
     it('allows passing Dialect config object as a dialect parameter', () => {
       expect(formatDialect('SELECT [foo], `bar`;', { dialect: sqlite })).toBe(dedent`


### PR DESCRIPTION
While fuzzing `format(format(x)) === format(x)`, I found a case where `denseOperators` turns valid SQL into something that means something different.

When a `-` operator is immediately followed by a negative operand, dense mode drops both spaces and collapses them into `--`:

```js
format("SELECT 1 - -1 AS x", { denseOperators: true })
// => "SELECT\n  1--1 AS x"
```

`--` starts a line comment, so `--1 AS x` is now a comment — the negation and the alias are silently dropped, and reformatting the output changes it again to `1 --1 AS x`. It happens both for a unary minus (`a - -b`) and for negative number literals (`1 - -1`). (BigQuery already keeps `-` spaced after #953, so it is unaffected.)

The fix is in the layout: if a token starting with `-` would land directly after one ending with `-`, keep a single space so the `--` marker can never form. Everything else stays dense (`a- -b`) and formatting is idempotent again.

Added a regression test to the shared operators feature test. Full test suite, typecheck, lint, prettier and build all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL formatting in dense mode to prevent `- -` sequences (e.g. `a - -b`, `1 - -1`) from being accidentally turned into `--` line comments.
  * Ensured `denseOperators: true` keeps the needed spacing boundaries so formatting is stable across re-runs. 
* **Tests**
  * Added coverage to verify the behavior and formatting idempotency for `a - -b` and `1 - -1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->