### PR TITLE
Upgrade to pnpm@11.9.0, remove `pmOnFail: download` config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
   pre_merge_checks:
     # Disable useless docstrings checks
     docstrings:
-      mode: disabled
+      mode: off
 
 chat:
   # Disable useless ASCII art or emojis in chat responses

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912"
+      "version": "11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,52 +7,52 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912
-        version: 11.0.8
+        specifier: 11.9.0
+        version: 11.9.0
       pnpm:
-        specifier: 11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912
-        version: 11.0.8
+        specifier: 11.9.0
+        version: 11.9.0
 
 packages:
 
-  '@pnpm/exe@11.0.8':
-    resolution: {integrity: sha512-TZAT5GddIropl7vXbGh+y4uIlPYUy0+i9DK4GGX2XTM4qvyICUfrAs3Hg574jbSM0RR9CCfHL78A0frQro44tw==}
+  '@pnpm/exe@11.9.0':
+    resolution: {integrity: sha512-pPPOpR79qW3nsNhlyDIdfstli4Bi78mk8r22ySxpFRwMbO8KXSjGrVzGmJBsVX39NnJTh7/WADj527nZhG9H9g==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.0.8':
-    resolution: {integrity: sha512-eJrvyl7ZK0IEHnO5Kot5/e95a0HytTPfqz8phJcIXbLKopSZXQoklp2GBu8oKBmHbGYypre+fJbgrXaS+7UwNw==}
+  '@pnpm/linux-arm64@11.9.0':
+    resolution: {integrity: sha512-XYmY2qadHauBA3QaHi2R7fI6kt5Flje0WHz9MVrbH0kVH/XLpfOLnwPeE1+EX6K/nDa2CBvzp35VjYCNGFJa9A==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.0.8':
-    resolution: {integrity: sha512-jrzzkskNRPyJvKeeJnxVNVrDWac8yUUOKu645WB8I+2zW2WjYhqPIJjHJ9BrC9zCYL1+oFrg9+hCu85+YVtLaQ==}
+  '@pnpm/linux-x64@11.9.0':
+    resolution: {integrity: sha512-fl7W5imnSmmgXIqMQFZ/rPaVvk9OkKF8/anqHZE3XEDfWcn3BlWGndyOEas/JN7u2BXWYjs63DJZ3rnG6WOhLA==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.0.8':
-    resolution: {integrity: sha512-+2Pi32x8/VZHNP2F9KQKKO2ND/lYUzOAVyp/z0J9CmIZF8DXEg+iPkw0h+By8TTu+Bd1ocqViiM67vYeuxBvvw==}
+  '@pnpm/linuxstatic-arm64@11.9.0':
+    resolution: {integrity: sha512-fif8xbnzVEAIlvaU4yIgWKXeXYb4Kj6WMEl/KvM2x1Rp3AKAjBW/53SGzxO4cZP9doAqUzOIpMRGFVbHGeMDRw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.0.8':
-    resolution: {integrity: sha512-0yRf1peDuZdDfowh2OSk+KMc/fkK+ftM605S3CpCa7P3DbTw49AV7biyqeLsVdioB9dCv15XC690jLio3VAUUw==}
+  '@pnpm/linuxstatic-x64@11.9.0':
+    resolution: {integrity: sha512-9dKu3QdShqOpnWrjW9owARpIJeP0ul8UgIIbBUv8VDGEYibt+g49zQsNaD7SdMD3WeRSjExPQ1zIhplzr5cwvQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.0.8':
-    resolution: {integrity: sha512-McMGN+OCNhhXjoySjtsWkEKWaT3YouV87+HvJi6P2Ww5VKu9TWVaIm0gPkwTOdiTDm1nUHvbFENzT9f7lWelFA==}
+  '@pnpm/macos-arm64@11.9.0':
+    resolution: {integrity: sha512-MWzBTgeI5p3odjdVltYvFXaSWAjF2Xk5YaxiP/u2RmW8N6PHsLyIyj37Ds992CrXgFM8fO1RpvsEirozhsD6KA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/win-arm64@11.0.8':
-    resolution: {integrity: sha512-UqaMayR9fxqsngebohEgZ68dwktHV/ZS3eEKgVbcJOzM91iLsuy5rA/1p7STptEM3iVOwuNH7bRvb6JEouCbrA==}
+  '@pnpm/win-arm64@11.9.0':
+    resolution: {integrity: sha512-u/QxEcbKJZxC1t3zUYCZiHzu7TaZ/iXc6EGZoQjkeVT0LXmEVR6ypcK3ByjhIqbxQ3HGX75gnpIpR+VjRjubfw==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.0.8':
-    resolution: {integrity: sha512-nrnQSDI1LTa9OR5TNcOnYA+6fhc31R62YupYpOxTVBOU8XxSFm7BxCX8KHn3h9S5HNrgPhWq1+bO5G/DlNGmDw==}
+  '@pnpm/win-x64@11.9.0':
+    resolution: {integrity: sha512-HqJVHmZG5UKfLi38AjMl2azVmq87TlWRhwSW+f4q9LLaZeAkFyIZ7LY/pN6mh4VlH9yWj90C+tsb1yKiy7OKnw==}
     cpu: [x64]
     os: [win32]
 
@@ -116,45 +116,45 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.0.8:
-    resolution: {integrity: sha512-TECX4d0tQjcsTn+lp5H/KPx1pITHrBkuZLHfD97xdZS6mC+bT+2a37PHV4RvVlt5mydj+zcz0d4by4LPRmhJEg==}
+  pnpm@11.9.0:
+    resolution: {integrity: sha512-vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.0.8':
+  '@pnpm/exe@11.9.0':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.0.8
-      '@pnpm/linux-x64': 11.0.8
-      '@pnpm/linuxstatic-arm64': 11.0.8
-      '@pnpm/linuxstatic-x64': 11.0.8
-      '@pnpm/macos-arm64': 11.0.8
-      '@pnpm/win-arm64': 11.0.8
-      '@pnpm/win-x64': 11.0.8
+      '@pnpm/linux-arm64': 11.9.0
+      '@pnpm/linux-x64': 11.9.0
+      '@pnpm/linuxstatic-arm64': 11.9.0
+      '@pnpm/linuxstatic-x64': 11.9.0
+      '@pnpm/macos-arm64': 11.9.0
+      '@pnpm/win-arm64': 11.9.0
+      '@pnpm/win-x64': 11.9.0
 
-  '@pnpm/linux-arm64@11.0.8':
+  '@pnpm/linux-arm64@11.9.0':
     optional: true
 
-  '@pnpm/linux-x64@11.0.8':
+  '@pnpm/linux-x64@11.9.0':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.0.8':
+  '@pnpm/linuxstatic-arm64@11.9.0':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.0.8':
+  '@pnpm/linuxstatic-x64@11.9.0':
     optional: true
 
-  '@pnpm/macos-arm64@11.0.8':
+  '@pnpm/macos-arm64@11.9.0':
     optional: true
 
-  '@pnpm/win-arm64@11.0.8':
+  '@pnpm/win-arm64@11.9.0':
     optional: true
 
-  '@pnpm/win-x64@11.0.8':
+  '@pnpm/win-x64@11.9.0':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -194,7 +194,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.0.8: {}
+  pnpm@11.9.0: {}
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,11 +11,6 @@ minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 
-# Work around pnpm bug where `pmOnFail` does not default to
-# 'download' with `devEngines.packageManager`
-# https://github.com/pnpm/pnpm/issues/11676
-pmOnFail: download
-
 # Prevent trust level decreases with packages newer than 60 days
 # to mitigate supply chain risks
 # https://pnpm.io/settings#trustpolicy


### PR DESCRIPTION
Upgrade to [`pnpm@11.9.0`](https://github.com/pnpm/pnpm/releases/tag/v11.9.0) and remove `pmOnFail: download` workaround:

- https://github.com/sql-formatter-org/sql-formatter/pull/949#pullrequestreview-4305290834
- my pnpm issue: https://github.com/pnpm/pnpm/issues/11676
- pnpm PR that fixed it: https://github.com/pnpm/pnpm/pull/11682
- pnpm release v11.1.3 that contained the fix: https://github.com/pnpm/pnpm/releases/tag/v11.1.3#:~:text=Fix%20devEngines.packageManager%20(singular%20form%2C%20without%20onFail)%20defaulting%20to%20onFail%3A%20%22error%22%20instead%20of%20the%20documented%20pmOnFail%3A%20%22download%22