### PR TITLE
fix(postgresql): keep spaces around OPERATOR() with denseOperators

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -339,6 +339,11 @@ export default class ExpressionFormatter {
     // would otherwise re-parse as a single dashed identifier.
     if (text === '-' && this.dialectCfg.identifierDashes) {
       this.layout.add(text, WS.SPACE);
+    } else if (/^OPERATOR\s*\(/iu.test(text)) {
+      // PostgreSQL's "OPERATOR(schema.+)" is a keyword-like operator. Densing it
+      // would glue it to its operands ("aOPERATOR(...)b") and re-parse as invalid
+      // SQL, so keep its surrounding spaces even with denseOperators.
+      this.layout.add(text, WS.SPACE);
     } else if (this.cfg.denseOperators || this.dialectCfg.alwaysDenseOperators.includes(text)) {
       this.layout.add(WS.NO_SPACE, text);
     } else if (text === ':') {

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -221,6 +221,19 @@ describe('PostgreSqlFormatter', () => {
     `);
   });
 
+  it('keeps spaces around OPERATOR() syntax with denseOperators', () => {
+    // Densing "foo OPERATOR(public.===) bar" into "fooOPERATOR(public.===)bar"
+    // glues the operands onto the keyword and re-parses as invalid SQL.
+    expect(format(`SELECT foo OPERATOR(public.===) bar;`, { denseOperators: true })).toBe(dedent`
+      SELECT
+        foo OPERATOR(public.===) bar;
+    `);
+    expect(format(`SELECT a OPERATOR(+) b;`, { denseOperators: true })).toBe(dedent`
+      SELECT
+        a OPERATOR(+) b;
+    `);
+  });
+
   // Issue #813
   it('supports OR REPLACE in CREATE FUNCTION', () => {
     expect(format(`CREATE OR REPLACE FUNCTION foo ();`)).toBe(dedent`


### PR DESCRIPTION
I was trying out `denseOperators` on some Postgres queries and noticed it mangles the `OPERATOR(schema.op)` syntax:

```
format('SELECT foo OPERATOR(public.===) bar;', { language: 'postgresql', denseOperators: true })
// =>
// SELECT
//   fooOPERATOR(public.===)bar;
```

The spaces around the operator get stripped, so `foo` runs into the `OPERATOR` keyword and the result no longer parses. Unlike `+`/`=`/etc., this one is keyword-like and can't be glued to its operands, so I made it keep its surrounding spaces even in dense mode — same idea as the existing `-` exception for dialects with dashed identifiers.

Added a test under the existing OPERATOR() case in postgresql.test.ts.