### PR TITLE
fix: remove extra space after BETWEEN _ AND _ expression

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -222,7 +222,7 @@ export default class ExpressionFormatter {
     this.layout = this.formatSubExpression(node.expr1);
     this.layout.add(WS.NO_SPACE, WS.SPACE, this.showNonTabularKw(node.andKw), WS.SPACE);
     this.layout = this.formatSubExpression(node.expr2);
-    this.layout.add(WS.SPACE);
+    this.layout.add(WS.NO_SPACE, WS.SPACE);
   }
 
   private formatCaseExpression(node: CaseExpressionNode) {

--- a/test/features/between.ts
+++ b/test/features/between.ts
@@ -19,7 +19,7 @@ export default function supportsBetween(format: FormatFn) {
 
   it('supports complex expressions inside BETWEEN', () => {
     // Not ideal, but better than crashing
-    expect(format('foo BETWEEN 1+2 AND 3+4')).toBe('foo BETWEEN 1 + 2 AND 3  + 4');
+    expect(format('foo BETWEEN 1+2 AND 3+4')).toBe('foo BETWEEN 1 + 2 AND 3 + 4');
   });
 
   it('supports CASE inside BETWEEN', () => {
@@ -27,6 +27,15 @@ export default function supportsBetween(format: FormatFn) {
       foo BETWEEN CASE x
         WHEN 1 THEN 2
       END AND 3
+    `);
+  });
+
+  it('does not add extra space after the BETWEEN expression', () => {
+    expect(format('SELECT CASE WHEN foo BETWEEN 1 AND 2 THEN 3 END')).toBe(dedent`
+      SELECT
+        CASE
+          WHEN foo BETWEEN 1 AND 2 THEN 3
+        END
     `);
   });
 

--- a/test/features/case.ts
+++ b/test/features/case.ts
@@ -209,7 +209,7 @@ export default function supportsCase(format: FormatFn) {
     expect(result).toBe(dedent`
     SELECT
       CASE
-        WHEN x1 BETWEEN 1 AND 12  THEN ''
+        WHEN x1 BETWEEN 1 AND 12 THEN ''
       END c1;
   `);
   });


### PR DESCRIPTION
I noticed the formatter emits two spaces after a BETWEEN predicate whenever something follows it on the same line. With default options:

```js
format('SELECT CASE WHEN foo BETWEEN 1 AND 2 THEN 3 END');
```

gives `WHEN foo BETWEEN 1 AND 2  THEN 3`. Same for `logicalOperatorNewline: 'after'` (`b BETWEEN 1 AND 2  AND`) and for `b BETWEEN 1 AND 2  IS TRUE`.

The cause is in `formatBetweenPredicate`: the sub-expression for the upper bound already ends with a trailing space, and the method then adds another `WS.SPACE` on top. It usually goes unnoticed because with the default `logicalOperatorNewline: 'before'` the following `WS.NEWLINE` trims the doubled space away. The lower bound already normalizes this with `WS.NO_SPACE, WS.SPACE`, so I did the same for the upper bound.

Two existing expectations had the extra space baked in (`test/features/between.ts` and `test/features/case.ts`); both are updated to the intended single space.

Tested with `pnpm run check` (typecheck, prettier, eslint, full jest suite) — all green. I also re-ran a format/re-format idempotency sweep over the repo's own test queries across every dialect and the option matrix; nothing changed apart from the removed space.