### PR TITLE
fix: keep DuckDB array-slice colon dense inside [ ]

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -43,6 +43,8 @@ interface ExpressionFormatterParams {
   params: Params;
   layout: Layout;
   inline?: boolean;
+  // openParen of the nearest enclosing bracket ("(", "[" or "{"), if any
+  enclosingBracket?: string;
 }
 
 export interface DialectFormatOptions {
@@ -76,13 +78,22 @@ export default class ExpressionFormatter {
   private inline = false;
   private nodes: AstNode[] = [];
   private index = -1;
+  private enclosingBracket?: string;
 
-  constructor({ cfg, dialectCfg, params, layout, inline = false }: ExpressionFormatterParams) {
+  constructor({
+    cfg,
+    dialectCfg,
+    params,
+    layout,
+    inline = false,
+    enclosingBracket,
+  }: ExpressionFormatterParams) {
     this.cfg = cfg;
     this.dialectCfg = dialectCfg;
     this.inline = inline;
     this.params = params;
     this.layout = layout;
+    this.enclosingBracket = enclosingBracket;
   }
 
   public format(nodes: AstNode[]): Layout {
@@ -194,7 +205,7 @@ export default class ExpressionFormatter {
   }
 
   private formatParenthesis(node: ParenthesisNode) {
-    const inlineLayout = this.formatInlineExpression(node.children);
+    const inlineLayout = this.formatInlineExpression(node.children, node.openParen);
 
     if (inlineLayout) {
       this.layout.add(node.openParen);
@@ -205,11 +216,11 @@ export default class ExpressionFormatter {
 
       if (isTabularStyle(this.cfg)) {
         this.layout.add(WS.INDENT);
-        this.layout = this.formatSubExpression(node.children);
+        this.layout = this.formatSubExpression(node.children, node.openParen);
       } else {
         this.layout.indentation.increaseBlockLevel();
         this.layout.add(WS.INDENT);
-        this.layout = this.formatSubExpression(node.children);
+        this.layout = this.formatSubExpression(node.children, node.openParen);
         this.layout.indentation.decreaseBlockLevel();
       }
 
@@ -346,6 +357,9 @@ export default class ExpressionFormatter {
       this.layout.add(text, WS.SPACE);
     } else if (this.cfg.denseOperators || this.dialectCfg.alwaysDenseOperators.includes(text)) {
       this.layout.add(WS.NO_SPACE, text);
+    } else if (text === ':' && this.enclosingBracket === '[') {
+      // Array slice colon (e.g. arr[1:5]) is dense; the key-value ":" keeps its space.
+      this.layout.add(WS.NO_SPACE, text);
     } else if (text === ':') {
       this.layout.add(WS.NO_SPACE, text, WS.SPACE);
     } else {
@@ -471,17 +485,21 @@ export default class ExpressionFormatter {
     }
   }
 
-  private formatSubExpression(nodes: AstNode[]): Layout {
+  private formatSubExpression(nodes: AstNode[], enclosingBracket = this.enclosingBracket): Layout {
     return new ExpressionFormatter({
       cfg: this.cfg,
       dialectCfg: this.dialectCfg,
       params: this.params,
       layout: this.layout,
       inline: this.inline,
+      enclosingBracket,
     }).format(nodes);
   }
 
-  private formatInlineExpression(nodes: AstNode[]): Layout | undefined {
+  private formatInlineExpression(
+    nodes: AstNode[],
+    enclosingBracket = this.enclosingBracket
+  ): Layout | undefined {
     const oldParamIndex = this.params.getPositionalParameterIndex();
     try {
       return new ExpressionFormatter({
@@ -490,6 +508,7 @@ export default class ExpressionFormatter {
         params: this.params,
         layout: new InlineLayout(this.cfg.expressionWidth),
         inline: true,
+        enclosingBracket,
       }).format(nodes);
     } catch (e) {
       if (e instanceof InlineLayoutError) {

--- a/test/duckdb.test.ts
+++ b/test/duckdb.test.ts
@@ -160,14 +160,21 @@ describe('DuckDBFormatter', () => {
     `);
   });
 
-  // TODO: This currently conflicts with ":"-operator in struct literals
-  it.skip('supports array slice operator', () => {
+  it('supports array slice operator', () => {
     expect(format('SELECT foo[:5], bar[1:], baz[1:5], zap[:];')).toBe(dedent`
       SELECT
         foo[:5],
         bar[1:],
         baz[1:5],
         zap[:];
+    `);
+  });
+
+  it('denses array-slice colon while keeping struct/list colon spaced', () => {
+    expect(format("SELECT {'k': list[1:5]}, arr[i:j];")).toBe(dedent`
+      SELECT
+        {'k': list[1:5]},
+        arr[i:j];
     `);
   });
 


### PR DESCRIPTION
DuckDB's array-slice operator formats with a stray space: `foo[:5]` comes out as `foo[: 5]` and `baz[1:5]` as `baz[1: 5]`.

## Root cause

Commit f9575c0 ("Support ':' as struct key-value separator") removed `':'` from DuckDB's `alwaysDenseOperators`, so struct literals like `{'a': 1}` keep the space after the colon. As a side effect the array-slice colon, which travels the same generic operator-spacing path, also became spaced. The identical test still passes for PostgreSQL (which keeps `':'` dense and has no struct literals), and the DuckDB copy was skipped with a `// TODO: This currently conflicts with ":"-operator in struct literals`.

The colon is genuinely context-dependent in DuckDB — dense inside `[...]` (array slice), spaced inside `{...}` (struct key) — but `alwaysDenseOperators` is a flat, dialect-global list with no notion of context, so neither setting is correct for both.

## Fix

Make the `':'` spacing decision depend on the nearest enclosing bracket rather than being dialect-global: dense inside `[...]`, spaced otherwise. The bracket context flows through the recursive `ExpressionFormatter` (each parenthesis passes its own `openParen` down to its children), so a struct nested in a list — `[{'a': 1}]` — still gets the spaced colon because its nearest bracket is `{`.

Only the colon-followed-by-a-value case was visibly wrong (`foo[:5]`, `baz[1:5]`); `bar[1:]` and `zap[:]` already rendered correctly because the trailing space was absorbed by the closing bracket.

## Tests

- Un-skips the pre-existing `supports array slice operator` test (all four forms: `foo[:5]`, `bar[1:]`, `baz[1:5]`, `zap[:]`).
- Adds a test pinning both directions in one statement — `{'k': list[1:5]}` — where the struct colon stays spaced while the slice colon is dense.

The four `formats {} struct literal ...` and `formats prefix aliases` tests double as an over-fix guard: making `:` dense unconditionally passes the slice test but breaks all of them. Full `pnpm test` is green across every dialect.

## Note

`alwaysDenseOperators` has no context mechanism today, so I threaded the bracket context through the formatter rather than widening that config surface. If you'd prefer a different shape (e.g. recognising the slice colon at the grammar level), happy to adjust.
