### PR TITLE
Avoid quadratic accumulation when parsing long SQL expression lists

### DIFF
--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -34,6 +34,20 @@ interface CommentAttachments {
   trailing?: CommentNode[];
 }
 
+interface ExpressionList {
+  previous?: ExpressionList;
+  value: AstNode;
+}
+
+const materializeExpressionList = (expressions?: ExpressionList): AstNode[] => {
+  const result: AstNode[] = [];
+  for (let current = expressions; current; current = current.previous) {
+    result.push(current.value);
+  }
+  result.reverse();
+  return result;
+};
+
 const addComments = (node: AstNode, { leading, trailing }: CommentAttachments): AstNode => {
   if (leading?.length) {
     node = { ...node, leadingComments: leading };
@@ -83,14 +97,24 @@ main -> statement:* {%
 statement -> expressions_or_clauses (%DELIMITER | %EOF) {%
   ([children, [delimiter]]) => ({
     type: NodeType.statement,
-    children,
+    children: materializeExpressionList(children),
     hasSemicolon: delimiter.type === TokenType.DELIMITER,
   })
 %}
 
 # To avoid ambiguity, plain expressions can only come before clauses
-expressions_or_clauses -> free_form_sql:* clause:* {%
-  ([expressions, clauses]) => [...expressions, ...clauses]
+# For performance, keep both in one persistent list until the surrounding rule is complete.
+expressions_or_clauses -> expression_list {% id %}
+expressions_or_clauses -> expressions_or_clauses clause {%
+  ([previous, value]) => ({ previous, value })
+%}
+
+# Avoid free_form_sql:*: Nearley implements it with array concatenation, which
+# copies every shared prefix and makes long expression lists quadratic.
+# Nearley's null matches no input; undefined represents an empty linked list.
+expression_list -> null {% () => undefined %}
+expression_list -> expression_list free_form_sql {%
+  ([previous, value]) => ({ previous, value })
 %}
 
 clause ->
@@ -119,11 +143,14 @@ limit_clause -> %LIMIT _ expression_chain_ (%COMMA free_form_sql:+):? {%
   }
 %}
 
-select_clause -> %RESERVED_SELECT (all_columns_asterisk free_form_sql:* | asteriskless_free_form_sql free_form_sql:*) {%
+select_clause -> %RESERVED_SELECT (all_columns_asterisk expression_list | asteriskless_free_form_sql expression_list) {%
   ([nameToken, [exp, expressions]]) => ({
     type: NodeType.clause,
     nameKw: toKeywordNode(nameToken),
-    children: [exp, ...expressions],
+    // Nearley completes every prefix; only materialize the surviving clause's children.
+    get children(): AstNode[] {
+      return [exp, ...materializeExpressionList(expressions)];
+    },
   })
 %}
 select_clause -> %RESERVED_SELECT {%
@@ -138,19 +165,23 @@ all_columns_asterisk -> %ASTERISK {%
   () => ({ type: NodeType.all_columns_asterisk })
 %}
 
-other_clause -> %RESERVED_CLAUSE free_form_sql:* {%
+other_clause -> %RESERVED_CLAUSE expression_list {%
   ([nameToken, children]) => ({
     type: NodeType.clause,
     nameKw: toKeywordNode(nameToken),
-    children,
+    get children(): AstNode[] {
+      return materializeExpressionList(children);
+    },
   })
 %}
 
-set_operation -> %RESERVED_SET_OPERATION free_form_sql:* {%
+set_operation -> %RESERVED_SET_OPERATION expression_list {%
   ([nameToken, children]) => ({
     type: NodeType.set_operation,
     nameKw: toKeywordNode(nameToken),
-    children,
+    get children(): AstNode[] {
+      return materializeExpressionList(children);
+    },
   })
 %}
 
@@ -232,25 +263,25 @@ function_call -> %RESERVED_FUNCTION_NAME _ parenthesis {%
 parenthesis -> "(" expressions_or_clauses ")" {%
   ([open, children, close]) => ({
     type: NodeType.parenthesis,
-    children: children,
+    children: materializeExpressionList(children),
     openParen: "(",
     closeParen: ")",
   })
 %}
 
-curly_braces -> "{" free_form_sql:* "}" {%
+curly_braces -> "{" expression_list "}" {%
   ([open, children, close]) => ({
     type: NodeType.parenthesis,
-    children: children,
+    children: materializeExpressionList(children),
     openParen: "{",
     closeParen: "}",
   })
 %}
 
-square_brackets -> "[" free_form_sql:* "]" {%
+square_brackets -> "[" expression_list "]" {%
   ([open, children, close]) => ({
     type: NodeType.parenthesis,
-    children: children,
+    children: materializeExpressionList(children),
     openParen: "[",
     closeParen: "]",
   })

--- a/test/perftest.ts
+++ b/test/perftest.ts
@@ -10,7 +10,7 @@ describe('Performance test', () => {
   });
 
   // Issue #840
-  it.skip('should use less than 100 MB of additional memory to format ~100 KB of SQL', () => {
+  it('should use less than 100 MB of additional memory to format ~100 KB of SQL', () => {
     // Long list of values
     const values = Array(10000).fill('myid');
     const sql = `SELECT ${values.join(', ')}`;
@@ -20,6 +20,33 @@ describe('Performance test', () => {
     format(sql, { language: 'sql' });
 
     expect(memoryUsageInMB()).toBeLessThan(BASELINE + 100);
+  });
+
+  it('formats all 10,000 values in a parenthesized IN list', () => {
+    const values = Array(10000).fill('myid');
+    const sql = `SELECT * FROM my_table WHERE col IN (${values.join(', ')})`;
+
+    const formatted = format(sql, { language: 'sql' });
+
+    expect(formatted.match(/\bmyid\b/g)).toHaveLength(values.length);
+  });
+
+  it('formats a parenthesized OR chain with 5,000 conditions', () => {
+    const conditions = Array(5000).fill('col = myid');
+    const sql = `SELECT * FROM my_table WHERE (${conditions.join(' OR ')})`;
+
+    const formatted = format(sql, { language: 'sql' });
+
+    expect(formatted.match(/\bOR\b/g)).toHaveLength(conditions.length - 1);
+  });
+
+  it('formats an unparenthesized OR chain with 5,000 conditions', () => {
+    const conditions = Array(5000).fill('col = myid');
+    const sql = `SELECT * FROM my_table WHERE ${conditions.join(' OR ')}`;
+
+    const formatted = format(sql, { language: 'sql' });
+
+    expect(formatted.match(/\bOR\b/g)).toHaveLength(conditions.length - 1);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace repeated array concatenation in SQL expression lists with persistent linked lists and defer array materialization until completed expressions are needed.
- Preserve grammar ambiguity handling and formatted output while covering large `IN` lists, long `OR` chains, and wide `SELECT` lists.
- Re-enable the existing memory regression for #840.

## Why

Nearley expands `free_form_sql:*` into an append postprocessor equivalent to `items.concat([item])`. Repeatedly copying every prefix produces quadratic allocation. For a representative 1,000-value `IN` query, these generated repetition postprocessors copied 1,997,014 prefix entries before this change and 10 afterward. Final AST construction still performs the necessary linear work: 3,004 list entries are materialized and another 3,000 entries are copied into completed arrays. Mutating the shared array with `.push()` is unsafe because alternative parses share prefixes.

`free_form_sql` remains the existing rule for one SQL element. The new `expression_list` recognizes exactly the same zero-or-more sequence as `free_form_sql:*`:

```nearley
expression_list -> null
expression_list -> expression_list free_form_sql
```

Each append instead creates an immutable `{ previous, value }` node. Consequently, `expressions_or_clauses -> expression_list clause:*` preserves the original grammar: free-form elements followed by structured clauses. Clause materialization is deferred because eagerly converting every intermediate parser candidate would reintroduce quadratic copying.

## Benchmarks

Apple M4 Max, Node.js 24.12.0. Values show median formatting time and whole-process peak RSS. Stress processes used a 384 MB V8 old-space limit.

| Input | Before | After |
| --- | --- | --- |
| Simple 9 KB query | 4.19 ms / 108 MB | 4.08 ms / 111 MB |
| 1,000-value `IN` | 21.35 ms / 190 MB | 13.07 ms / 90 MB |
| 3,000-value `IN` | 107.25 ms / 444 MB | 34.47 ms / 109 MB |
| 10,000-value `IN` | Out of memory | 97.98 ms / 157 MB |
| 5,000-condition `OR` chain | Out of memory | 104.61 ms / 157 MB |
| 10,000-column `SELECT` | Out of memory | 110.04 ms / 229 MB |

## Validation

- `pnpm run grammar`
- `pnpm run ts:check`
- `pnpm run pretty:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec jest --runInBand --silent --coverage=false`: 27 suites, 5,841 tests, and 63 snapshots passed.
- Re-enabled issue #840 performance regression passed.
- 1,000 generated differential SQL cases preserved existing output and rejection behavior.

Closes #840.
