### PR TITLE
fix: keep PostgreSQL CREATE POLICY FOR/WITH CHECK together

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ bingou
 Boris Verkhovskiy <boris.verk@gmail.com>
 Christian Jorgensen <chr.jorgensen1@gmail.com>
 Christopher Manouvrier <chris@dovetailapp.com>
+cnbei <cnbay@outlook.com>
 Damon Davison <ddavison@avalere.com>
 Daniël van Eeden <daniel.van.eeden@pingcap.com>
 Davut Can Abacigil <can@teamsql.io>

--- a/src/languages/postgresql/postgresql.formatter.ts
+++ b/src/languages/postgresql/postgresql.formatter.ts
@@ -19,6 +19,8 @@ const reservedClauses = expandPhrases([
   'OFFSET',
   'FETCH {FIRST | NEXT}',
   'FOR {UPDATE | NO KEY UPDATE | SHARE | KEY SHARE} [OF]',
+  // CREATE/ALTER POLICY (issue #928)
+  'FOR {SELECT | INSERT | DELETE}',
   // Data manipulation
   // - insert:
   'INSERT INTO',
@@ -265,6 +267,8 @@ const reservedKeywordPhrases = expandPhrases([
   'IS [NOT] DISTINCT FROM',
   'NULLS {FIRST | LAST}',
   'WITH ORDINALITY',
+  // CREATE/ALTER POLICY: do not treat WITH CHECK as a CTE WITH clause (issue #928)
+  'WITH CHECK',
 ]);
 
 const reservedDataTypePhrases = expandPhrases([

--- a/test/postgresql.test.ts
+++ b/test/postgresql.test.ts
@@ -224,6 +224,64 @@ describe('PostgreSqlFormatter', () => {
     `);
   });
 
+  // Issue #928
+  it('formats CREATE POLICY FOR SELECT and FOR INSERT consistently', () => {
+    expect(
+      format(`
+        CREATE POLICY "Allow users to select their own records" ON public.user_achievements
+          FOR SELECT
+          TO authenticated
+          USING (user_id = auth.uid());
+
+        CREATE POLICY "Allow users to insert their own records" ON public.user_achievements
+          FOR INSERT
+          TO authenticated
+          WITH CHECK (user_id = auth.uid());
+      `)
+    ).toBe(dedent`
+      CREATE POLICY "Allow users to select their own records" ON public.user_achievements
+      FOR SELECT
+        TO authenticated USING (user_id = auth.uid ());
+
+      CREATE POLICY "Allow users to insert their own records" ON public.user_achievements
+      FOR INSERT
+        TO authenticated WITH CHECK (user_id = auth.uid ());
+    `);
+  });
+
+  it('formats CREATE POLICY FOR DELETE and WITH CHECK', () => {
+    expect(
+      format(`
+        CREATE POLICY p_del ON public.t
+          FOR DELETE
+          TO authenticated
+          USING (user_id = auth.uid());
+
+        CREATE POLICY p_ins ON public.t
+          WITH CHECK (true);
+      `)
+    ).toBe(dedent`
+      CREATE POLICY p_del ON public.t
+      FOR DELETE
+        TO authenticated USING (user_id = auth.uid ());
+
+      CREATE POLICY p_ins ON public.t WITH CHECK (true);
+    `);
+  });
+
+  it('formats ALTER POLICY USING and WITH CHECK', () => {
+    expect(
+      format(`
+        ALTER POLICY p ON public.t
+          TO authenticated
+          USING (user_id = 1)
+          WITH CHECK (user_id = 1);
+      `)
+    ).toBe(dedent`
+      ALTER POLICY p ON public.t TO authenticated USING (user_id = 1) WITH CHECK (user_id = 1);
+    `);
+  });
+
   // Issue #711
   it('supports OPERATOR() syntax', () => {
     expect(format(`SELECT foo OPERATOR(public.===) bar;`)).toBe(dedent`


### PR DESCRIPTION
Fixes #928

SELECT is a reserved clause and WITH starts a CTE, so FOR SELECT wrapped differently from FOR INSERT, and WITH CHECK split onto two lines. Treat FOR SELECT/INSERT/DELETE as reserved clauses (alongside existing FOR UPDATE) and WITH CHECK as a reserved keyword phrase.

postgresql.test.ts: 462 passed.