### PR TITLE
fix: support -- sql-formatter-disable line comments

### DIFF
--- a/src/formatter/ExpressionFormatter.ts
+++ b/src/formatter/ExpressionFormatter.ts
@@ -406,7 +406,13 @@ export default class ExpressionFormatter {
   }
 
   private formatBlockComment(node: BlockCommentNode | DisableCommentNode) {
-    if (node.type === NodeType.block_comment && this.isStandaloneBlockComment(node)) {
+    if (node.type === NodeType.disable_comment) {
+      this.layout.add(node.text, WS.SPACE);
+      // Place following SQL on the next indented line after a multi-line region.
+      if (isMultiline(node.text)) {
+        this.layout.add(WS.NEWLINE, WS.INDENT);
+      }
+    } else if (this.isStandaloneBlockComment(node)) {
       this.splitBlockComment(node.text).forEach(line => {
         this.layout.add(WS.NEWLINE, WS.INDENT, line);
       });

--- a/src/lexer/Tokenizer.ts
+++ b/src/lexer/Tokenizer.ts
@@ -37,6 +37,11 @@ export default class Tokenizer {
           /(\/\* *sql-formatter-disable *\*\/[\s\S]*?(?:\/\* *sql-formatter-enable *\*\/|$))/uy,
       },
       {
+        type: TokenType.DISABLE_COMMENT,
+        regex:
+          /(-- *sql-formatter-disable\b[^\n\r]*(?:(?:\r\n|\r|\n)[\s\S]*?(?:-- *sql-formatter-enable\b[^\n\r]*|$)|$))/uy,
+      },
+      {
         type: TokenType.BLOCK_COMMENT,
         regex: cfg.nestedBlockComments ? new NestedComment() : /(\/\*[^]*?\*\/)/uy,
       },

--- a/src/lexer/token.ts
+++ b/src/lexer/token.ts
@@ -34,7 +34,8 @@ export enum TokenType {
   CLOSE_PAREN = 'CLOSE_PAREN',
   LINE_COMMENT = 'LINE_COMMENT',
   BLOCK_COMMENT = 'BLOCK_COMMENT',
-  // Text between /* sql-formatter-disable */ and /* sql-formatter-enable */
+  // Text between sql-formatter-disable and sql-formatter-enable comments
+  // (either /* ... */ or -- ... line comments)
   DISABLE_COMMENT = 'DISABLE_COMMENT',
   NUMBER = 'NUMBER',
   NAMED_PARAMETER = 'NAMED_PARAMETER',

--- a/test/features/disableComment.ts
+++ b/test/features/disableComment.ts
@@ -83,4 +83,114 @@ export default function supportsDisableComment(format: FormatFn) {
         bar;
     `);
   });
+
+  it('does not format text between -- sql-formatter-disable and -- sql-formatter-enable', () => {
+    const result = format(dedent`
+      SELECT foo FROM bar;
+      -- sql-formatter-disable
+      SELECT foo FROM bar;
+      -- sql-formatter-enable
+      SELECT foo FROM bar;
+    `);
+
+    expect(result).toBe(dedent`
+      SELECT
+        foo
+      FROM
+        bar;
+
+      -- sql-formatter-disable
+      SELECT foo FROM bar;
+      -- sql-formatter-enable
+      SELECT
+        foo
+      FROM
+        bar;
+    `);
+  });
+
+  // Issue #912
+  it('preserves indentation between -- sql-formatter-disable and -- sql-formatter-enable', () => {
+    const result = format(dedent`
+      -- sql-formatter-disable
+      SELECT
+        foo
+          FROM
+            bar;
+      -- sql-formatter-enable
+    `);
+
+    expect(result).toBe(dedent`
+      -- sql-formatter-disable
+      SELECT
+        foo
+          FROM
+            bar;
+      -- sql-formatter-enable
+    `);
+  });
+
+  it('does not format text after -- sql-formatter-disable until end of file', () => {
+    const result = format(dedent`
+      SELECT foo FROM bar;
+      -- sql-formatter-disable
+      SELECT foo FROM bar;
+
+      SELECT foo FROM bar;
+    `);
+
+    expect(result).toBe(dedent`
+      SELECT
+        foo
+      FROM
+        bar;
+
+      -- sql-formatter-disable
+      SELECT foo FROM bar;
+
+      SELECT foo FROM bar;
+    `);
+  });
+
+  it('does not parse code between -- disable/enable comments', () => {
+    const result = format(dedent`
+      SELECT
+      -- sql-formatter-disable
+      ?!{}[]
+      -- sql-formatter-enable
+      FROM bar;
+    `);
+
+    expect(result).toBe(dedent`
+      SELECT
+        -- sql-formatter-disable
+      ?!{}[]
+      -- sql-formatter-enable
+      FROM
+        bar;
+    `);
+  });
+
+  // Issue #912
+  it('does not format sqlc.embed() between -- sql-formatter-disable comments', () => {
+    const result = format(dedent`
+      SELECT
+      -- sql-formatter-disable
+        sqlc.embed(users),
+      -- sql-formatter-enable
+        customers.id
+      FROM
+        customers
+    `);
+
+    expect(result).toBe(dedent`
+      SELECT
+        -- sql-formatter-disable
+        sqlc.embed(users),
+      -- sql-formatter-enable
+        customers.id
+      FROM
+        customers
+    `);
+  });
 }


### PR DESCRIPTION
Fixes #912

Block comments already supported sql-formatter-disable / enable. Line comments -- sql-formatter-disable did not, so sqlc.embed(users) and similar were still reformatted.

Treat -- sql-formatter-disable ... -- sql-formatter-enable (or EOF) as one DISABLE_COMMENT token so inner SQL is not parsed. Jest: 5944 passed, 1 skipped.